### PR TITLE
Filter by department

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ before_script:
 - psql -c 'create database purchasing_test;' -U postgres
 script: PYTHONPATH=. nosetests purchasing_test/ -sv --with-coverage --cover-package=purchasing
 notifications:
+  webhooks: http://project-monitor.codeforamerica.org/projects/6a9169a2-749e-197b-b402-d7b2fd555d31/status
   slack:
     secure: VW0HQTnMb4L8svSdzHZMx16Mte79Y4DmZxeItWtSvdlKUT/oKwYuzLASA/o3/ixNBLugcfxht+rTnQQITnKlwQ5n4gxvV2ynXyBi4YAkYr3lvc74pvfsbiE1Auv7NYiX6dPZW9OAtKYZVVxIJTp7PiLpeyDiQVe2Ro0r3GtK4y8=
 branches:

--- a/purchasing/admin/views.py
+++ b/purchasing/admin/views.py
@@ -1,5 +1,7 @@
+# -*- coding: utf-8 -*-
 from flask import url_for, request
 
+from wtforms.fields import SelectField
 from purchasing.extensions import admin, db
 from purchasing.decorators import AuthMixin, SuperAdminMixin
 from flask_admin.contrib import sqla
@@ -9,7 +11,7 @@ from purchasing.data.models import (
     Company, CompanyContact
 )
 from purchasing.extensions import login_manager
-from purchasing.users.models import User, Role
+from purchasing.users.models import User, Role, DEPARTMENT_CHOICES
 
 @login_manager.user_loader
 def load_user(userid):
@@ -44,7 +46,12 @@ class FlowAdmin(AuthMixin, sqla.ModelView):
     form_columns = ['flow_name', 'stage_order']
 
 class UserAdmin(AuthMixin, sqla.ModelView):
-    form_columns = ['email', 'first_name', 'last_name']
+    form_columns = ['email', 'first_name', 'last_name', 'department']
+
+    form_overrides = dict(department=SelectField)
+    form_args = dict(department={
+        'choices': DEPARTMENT_CHOICES
+    })
 
     def is_accessible(self):
         if current_user.is_anonymous():
@@ -53,7 +60,7 @@ class UserAdmin(AuthMixin, sqla.ModelView):
             return True
 
 class UserRoleAdmin(SuperAdminMixin, sqla.ModelView):
-    form_columns = ['email', 'first_name', 'last_name', 'role']
+    form_columns = ['email', 'first_name', 'last_name', 'department', 'role']
 
 class RoleAdmin(SuperAdminMixin, sqla.ModelView):
     pass

--- a/purchasing/static/less/_styles.less
+++ b/purchasing/static/less/_styles.less
@@ -4,12 +4,17 @@
 
 /* universal */
 
+@import "_variables.less";
+
 html {
   overflow-y: scroll;
+  position: relative;
+  min-height: 100%;
 }
 
 body {
   padding-top: 60px;
+  margin-bottom: @footer-height;
 }
 
 section {
@@ -97,4 +102,12 @@ footer .footer-nav {
 
 footer a {
   color: @link-color;
+}
+
+.spacer-20 {
+  padding-bottom: 20px;
+}
+
+.spacer-10 {
+  padding-bottom: 10px;
 }

--- a/purchasing/templates/footer.html
+++ b/purchasing/templates/footer.html
@@ -1,15 +1,17 @@
 <footer class="footer">
-  <small>
-  <ul class="company">
-    <li>Made by <a href="http://www.codeforamerica.org/">Code for America</a> and the <a href="http://pittsburghpa.gov/innovation-performance/home">Pittsburgh Department of Innovation and Performance</a>
-    </li>
-  </ul>
-
-    <ul class="footer-nav">
-
-      <li><a href="{{ url_for('public.about') }}">About</a></li>
-
-      <li><a href="mailto:bsmithgall@codeforamerica.org">Contact</a></li>
+  <div class="container">
+    <small>
+    <ul class="company">
+      <li>Made by <a href="http://www.codeforamerica.org/">Code for America</a> and the <a href="http://pittsburghpa.gov/innovation-performance/home">Pittsburgh Department of Innovation and Performance</a>
+      </li>
     </ul>
-  </small>
+
+      <ul class="footer-nav">
+
+        <li><a href="{{ url_for('public.about') }}">About</a></li>
+
+        <li><a href="mailto:bsmithgall@codeforamerica.org">Contact</a></li>
+      </ul>
+    </small>
+  </div>
 </footer>

--- a/purchasing/templates/public/about.html
+++ b/purchasing/templates/public/about.html
@@ -3,10 +3,10 @@
 
 {% block content %}
 <div class="body-content">
-    <div class="row">
-      <h1>About</h1>
-      <p>This template was created by <a href="http://github.com/sloria/">Steven Loria</a> for use with the <a href="http://github.com/audreyr/cookiecutter/">cookiecutter</a> package by <a href="http://github.com/audreyr/">Audrey Roy</a>.</p>
-    </div>
+  <div class="row">
+    <h2>About</h2>
+    <p>The Pittsburgh Purchasing Suite is a collection of apps to help purchasers. It includes <a href="{{ url_for('wexplorer.explore') }}">Wexplorer</a>, a tool for discovering items that are on contract right now, and <a href="{{ url_for('public.home') }}">Sherpa</a>, a tool for understanding the procurement process and helping navigate specific pieces.
+  </div>
 </div>
 {% endblock %}
 

--- a/purchasing/templates/wexplorer/explore.html
+++ b/purchasing/templates/wexplorer/explore.html
@@ -8,26 +8,31 @@
 
   <h2>helps you find goods and services</h2>
 
+  <div class="spacer-10"></div>
+
   <form id="search-box" method="GET" class="form form-inline" action="{{ url_for('wexplorer.search') }}">
+
+    <h4>
+      Search company names and contract descriptions,
+    </h4>
     <div class="form-group">
       {{ search_form.q(placeholder="I'm looking for...", class_="form-control input-lg") }}
     </div>
-    <input class="btn btn-default btn-success input-lg" type="submit" value="Search">
-  </form>
 
-    <div class="spacer-20"></div>
-
-    <h4 class="text-muted">
-      Search company names and contract descriptions.
+    <h4>
+      <div class="spacer-10"></div>
+      or see what contracts a department is using.
     </h4>
 
-    <h3>Or, see what contracts a department is using.</h3>
+    <div class="spacer-10"></div>
 
-  <form id="filter-box" method="GET" class="form form-inline" action="{{ url_for('wexplorer.filter') }}">
     <div class="form-group">
       {{ search_form.department(class_="form-control") }}
     </div>
-    <input class="btn btn-default btn-success" type="submit" value="Search">
+
+    <div class="spacer-20"></div>
+
+    <input class="btn btn-default btn-success input-lg" type="submit" value="Search">
   </form>
 
 </div>

--- a/purchasing/templates/wexplorer/explore.html
+++ b/purchasing/templates/wexplorer/explore.html
@@ -7,21 +7,28 @@
   <a href="{{ url_for('wexplorer.explore') }}"><img class="big-logo" src="{{ url_for('static', filename='img/wexplorer-logo.png') }}"></a>
 
   <h2>helps you find goods and services</h2>
-  <h2 class="text-muted padded-bottom h2-mobile-fixed-two-rows"><strong id="js-cycle-phrases">for the lowest price.</strong></h2>
 
-  <form id="search-box" method="GET" class="form form-inline" action="{{ url_for('wexplorer.search') }}" role="login">
+  <form id="search-box" method="GET" class="form form-inline" action="{{ url_for('wexplorer.search') }}">
     <div class="form-group">
       {{ search_form.q(placeholder="I'm looking for...", class_="form-control input-lg") }}
     </div>
     <input class="btn btn-default btn-success input-lg" type="submit" value="Search">
   </form>
 
-  <div class="spacer-20"></div>
+    <div class="spacer-20"></div>
 
-  <h4 class="text-muted">
-    Search company names, contract descriptions, controller numbers, <br />
-    spec numbers, or items that have been entered into Wexplorer.
-  </h4>
+    <h4 class="text-muted">
+      Search company names and contract descriptions.
+    </h4>
+
+    <h3>Or, see what contracts a department is using.</h3>
+
+  <form id="filter-box" method="GET" class="form form-inline" action="{{ url_for('wexplorer.filter') }}">
+    <div class="form-group">
+      {{ search_form.department(class_="form-control") }}
+    </div>
+    <input class="btn btn-default btn-success" type="submit" value="Search">
+  </form>
 
 </div>
 

--- a/purchasing/templates/wexplorer/filter.html
+++ b/purchasing/templates/wexplorer/filter.html
@@ -1,0 +1,27 @@
+{% extends 'wexplorer/layout.html' %}
+{% import 'macros/render_pagination.html' as macros %}
+{% block content %}
+
+<div class="row">
+  <div class="col-md-3">
+    {% include 'wexplorer/shared/side_search.html' %}
+  </div>
+
+  <div class="col-md-9">
+  {% if results %}
+    <h3>Here are the contracts that have subscribers from {{ department }}:</h3>
+    <ul>
+    {% for result in results %}
+      <li><a href="{{ url_for('wexplorer.contract', contract_id=result.id) }}">{{ result.description }}</a></li>
+    {% endfor %}
+    </ul>
+    {% if pagination.pages > 1 %}
+      {{ macros.render_pagination(pagination) }}
+    {% endif %}
+  {% else %}
+    <h4>No one from this department has subscribed to any contracts yet! Why not try searching instead?</h4>
+  {% endif %}
+  </div>
+
+</div>
+{% endblock %}

--- a/purchasing/templates/wexplorer/filter.html
+++ b/purchasing/templates/wexplorer/filter.html
@@ -10,10 +10,20 @@
   <div class="col-md-9">
   {% if results %}
     <h3>Here are the contracts that have subscribers from {{ department }}:</h3>
+    <table class="table">
+      <thead>
+        <tr><th>Contract</th><th>Number of Subscribers</th>
+      </thead>
+      <tbody>
+      {% for result in results %}
+        <tr>
+          <td><a href="{{ url_for('wexplorer.contract', contract_id=result.id) }}">{{ result.description }}</a></td>
+          <td>{{ result.cnt }}</td>
+        </tr>
+      {% endfor %}
+      </tbody>
+    </table>
     <ul>
-    {% for result in results %}
-      <li><a href="{{ url_for('wexplorer.contract', contract_id=result.id) }}">{{ result.description }}</a></li>
-    {% endfor %}
     </ul>
     {% if pagination.pages > 1 %}
       {{ macros.render_pagination(pagination) }}

--- a/purchasing/templates/wexplorer/search.html
+++ b/purchasing/templates/wexplorer/search.html
@@ -2,13 +2,13 @@
 {% import 'macros/render_pagination.html' as macros %}
 {% block content %}
 
-{% if results %}
 
 <div class="row">
   <div class="col-md-3">
     {% include 'wexplorer/shared/side_search.html' %}
   </div>
   <div class="col-md-9">
+  {% if results %}
     <h3 class="text-muted">
       {{ pagination.total_count }} results found for "{{ request.args.get('q') }}"
       {% if pagination.pages > 1 %}({{ (results | length) }} shown) {% endif %}<br>
@@ -51,11 +51,11 @@
       {{ macros.render_pagination(pagination) }}
     {% endif %}
   </div>
+  {% else %}
+  <div class="row text-center">
+    <h4>There are no results!</h4>
+  </div>
+  {% endif %}
 </div>
-{% else %}
-<div class="row text-center">
-  <h4>There are no results!</h4>
-</div>
-{% endif %}
 
 {% endblock %}

--- a/purchasing/templates/wexplorer/shared/side_search.html
+++ b/purchasing/templates/wexplorer/shared/side_search.html
@@ -3,9 +3,12 @@
   <a href="{{ url_for('wexplorer.explore') }}"><img src="{{ url_for('static', filename='img/wexplorer-logo.png') }}" class="side-nav-logo"></a>
 
 
-  <form id="search-box" method="GET" class="form form-inline" action="{{ url_for('wexplorer.search') }}" role="login">
+  <form id="search-box" method="GET" class="form" action="{{ url_for('wexplorer.search') }}" role="login">
     <div class="form-group">
       {{ search_form.q(placeholder="I'm looking for...", class_="form-control") }}
+    </div>
+    <div class="form-group">
+      {{ search_form.department(class_="form-control") }}
     </div>
     <input class="btn btn-default btn-success" type="submit" value="Search">
   </form>

--- a/purchasing/templates/wexplorer/shared/side_search.html
+++ b/purchasing/templates/wexplorer/shared/side_search.html
@@ -5,9 +5,11 @@
 
   <form id="search-box" method="GET" class="form" action="{{ url_for('wexplorer.search') }}" role="login">
     <div class="form-group">
+      <label for="q">Search by description or company:</label>
       {{ search_form.q(placeholder="I'm looking for...", class_="form-control") }}
     </div>
     <div class="form-group">
+      <label for="department">Filter by a Department:</label>
       {{ search_form.department(class_="form-control") }}
     </div>
     <input class="btn btn-default btn-success" type="submit" value="Search">

--- a/purchasing/users/models.py
+++ b/purchasing/users/models.py
@@ -12,6 +12,12 @@ from purchasing.database import (
     SurrogatePK,
 )
 
+DEPARTMENT_CHOICES = [
+    ('Innovation and Performance', 'Innovation and Performance'),
+    ('Office of Management and Budget', 'Office of Management and Budget'),
+    ('Other', 'Other')
+]
+
 class Role(SurrogatePK, Model):
     __tablename__ = 'roles'
     name = Column(db.String(80), unique=True, nullable=False)
@@ -33,6 +39,7 @@ class User(UserMixin, SurrogatePK, Model):
     created_at = Column(db.DateTime, nullable=False, default=dt.datetime.utcnow)
     first_name = Column(db.String(30), nullable=True)
     last_name = Column(db.String(30), nullable=True)
+    department = Column(db.String(255), nullable=False)
     active = Column(db.Boolean(), default=False)
     role_id = ReferenceCol('roles', ondelete='SET NULL', nullable=True)
 

--- a/purchasing/users/models.py
+++ b/purchasing/users/models.py
@@ -13,6 +13,7 @@ from purchasing.database import (
 )
 
 DEPARTMENT_CHOICES = [
+    ('', '-----'),
     ('Innovation and Performance', 'Innovation and Performance'),
     ('Office of Management and Budget', 'Office of Management and Budget'),
     ('Other', 'Other')

--- a/purchasing/utils.py
+++ b/purchasing/utils.py
@@ -34,6 +34,10 @@ class SimplePagination(object):
     def has_prev(self):
         return self.page > 1
 
+    @property
+    def has_next(self):
+        return self.page < self.pages
+
     def iter_pages(self, left_edge=2, left_current=2, right_current=5, right_edge=2):
         last = 0
         for num in xrange(1, self.pages + 1):

--- a/purchasing/wexplorer/forms.py
+++ b/purchasing/wexplorer/forms.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -*-
 from flask_wtf import Form
-from wtforms import TextField
+from wtforms.fields import TextField, SelectField
 from wtforms.validators import DataRequired
+from purchasing.users.models import DEPARTMENT_CHOICES
 
 class SearchForm(Form):
     q = TextField('Search', validators=[DataRequired()])
+    department = SelectField(choices=DEPARTMENT_CHOICES)
 
     def __init__(self, *args, **kwargs):
         super(SearchForm, self).__init__(*args, **kwargs)

--- a/purchasing/wexplorer/views.py
+++ b/purchasing/wexplorer/views.py
@@ -71,6 +71,10 @@ def search():
     The search results page for wexplorer. Renders the "side search"
     along with paginated results.
     '''
+    department = request.args.get('department')
+    if department and department != '':
+        return redirect(url_for('wexplorer.filter', department=department))
+
     search_form = SearchForm(request.form)
     search_for = request.args.get('q', '')
     results = []

--- a/purchasing/wexplorer/views.py
+++ b/purchasing/wexplorer/views.py
@@ -9,7 +9,7 @@ from flask_login import current_user
 from purchasing.database import db
 from purchasing.utils import SimplePagination
 from purchasing.decorators import wrap_form, requires_roles
-from purchasing.wexplorer.forms import SearchForm
+from purchasing.wexplorer.forms import SearchForm, DEPARTMENT_CHOICES
 from purchasing.data.models import ContractBase
 from purchasing.data.companies import get_one_company
 from purchasing.data.contracts import (
@@ -31,7 +31,6 @@ def explore():
     return dict(current_user=current_user)
 
 @blueprint.route('/filter', methods=['GET'])
-@wrap_form(SearchForm, 'search_form', 'wexplorer/filter.html')
 def filter():
     '''
     Filter contracts by which ones have departmental subscribers
@@ -43,8 +42,8 @@ def filter():
     lower_bound_result = (page - 1) * pagination_per_page
     upper_bound_result = lower_bound_result + pagination_per_page
 
-    if department is None:
-        flash('You must choose a department!', 'alert-danger')
+    if department is None or department not in [i[0] for i in DEPARTMENT_CHOICES]:
+        flash('You must choose a valid department!', 'alert-danger')
         return redirect(url_for('wexplorer.explore'))
 
     contracts = ContractBase.query.filter(
@@ -55,7 +54,9 @@ def filter():
 
     results = contracts[lower_bound_result:upper_bound_result]
 
-    return dict(
+    return render_template(
+        'wexplorer/filter.html',
+        search_form=SearchForm(),
         results=results,
         pagination=pagination,
         department=department,

--- a/purchasing/wexplorer/views.py
+++ b/purchasing/wexplorer/views.py
@@ -113,6 +113,7 @@ def search():
         LEFT OUTER JOIN
         users u
         ON cca.user_id = u.id
+        WHERE x.contract_id IS NOT NULL
         group by 1,2,3,4
         ''',
         {

--- a/purchasing_test/unit/test_base.py
+++ b/purchasing_test/unit/test_base.py
@@ -27,12 +27,16 @@ class BaseTestCase(TestCase):
         Taken from: http://blog.paulopoiati.com/2013/02/22/testing-flash-messages-in-flask/
         '''
         with self.client.session_transaction() as session:
+            messages, categories = [], []
             try:
-                category, message = session['_flashes'][0]
+                flashes = session['_flashes']
+                for flash in flashes:
+                    categories.append(flash[0])
+                    messages.append(flash[1])
             except KeyError:
                 raise AssertionError('nothing flashed')
-            assert expected_message in message
-            assert expected_category == category
+            assert expected_message in messages
+            assert expected_category in categories
 
     @patch('urllib2.urlopen')
     def login_user(self, user, urlopen):

--- a/purchasing_test/unit/util.py
+++ b/purchasing_test/unit/util.py
@@ -71,11 +71,11 @@ def insert_a_company(name='test company', insert_contract=True):
 
     return company
 
-def create_a_user(email='foo@foo.com', role=None):
-    return User(email=email, first_name='foo', last_name='foo', role_id=role)
+def create_a_user(email='foo@foo.com', department='Other', role=None):
+    return User(email=email, first_name='foo', last_name='foo', department=department, role_id=role)
 
-def insert_a_user(email='foo@foo.com', role=None):
-    user = create_a_user(email, role)
+def insert_a_user(email='foo@foo.com', department='Other', role=None):
+    user = create_a_user(email, department, role)
     user.save()
     return user
 

--- a/purchasing_test/unit/wexplorer/test_wexplorer.py
+++ b/purchasing_test/unit/wexplorer/test_wexplorer.py
@@ -122,9 +122,16 @@ class TestWexplorer(BaseTestCase):
         self.client.get('/wexplorer/contracts/1/subscribe')
         self.client.get('/wexplorer/contracts/2/subscribe')
 
+        # login as superadmin user and subscribe to one contract
+        self.login_user(self.superadmin_user)
+        self.client.get('/wexplorer/contracts/1/subscribe')
+
         # filter by contracts associated with Other department
         self.client.get('/wexplorer/filter?department=Other')
         self.assertEquals(len(self.get_context_variable('results')), 2)
+        # assert that contract 1 is first
+        self.assertEquals(self.get_context_variable('results')[0].id, 1)
+        self.assertEquals(self.get_context_variable('results')[0].cnt, 2)
 
         # assert innovation and performance has no results
         self.client.get('/wexplorer/filter?department=Innovation+and+Performance')

--- a/purchasing_test/unit/wexplorer/test_wexplorer.py
+++ b/purchasing_test/unit/wexplorer/test_wexplorer.py
@@ -9,7 +9,7 @@ from purchasing_test.unit.util import (
 from purchasing.data.models import ContractBase
 
 class TestWexplorer(BaseTestCase):
-    render_templates = False
+    render_templates = True
 
     def setUp(self):
         super(TestWexplorer, self).setUp()
@@ -35,17 +35,20 @@ class TestWexplorer(BaseTestCase):
         self.assertTrue(self.get_context_variable('search_form') is not None)
 
     def test_search(self):
-        self.client.get('/wexplorer/search?q=aaa')
+        self.assert200(self.client.get('/wexplorer/search?q=aaa'))
         self.assertEquals(len(self.get_context_variable('results')), 1)
 
-        self.client.get('/wexplorer/search?q=BB')
+        self.assert200(self.client.get('/wexplorer/search?q=BB'))
         self.assertEquals(len(self.get_context_variable('results')), 1)
 
-        self.client.get('/wexplorer/search?q=CC')
+        self.assert200(self.client.get('/wexplorer/search?q=CC'))
         self.assertEquals(len(self.get_context_variable('results')), 2)
 
-        self.client.get('/wexplorer/search?q=dd')
+        self.assert200(self.client.get('/wexplorer/search?q=dd'))
         self.assertEquals(len(self.get_context_variable('results')), 2)
+
+        self.assert200(self.client.get('/wexplorer/search?q=FAKEFAKEFAKE'))
+        self.assertEquals(len(self.get_context_variable('results')), 0)
 
     def test_companies(self):
         request = self.client.get('/wexplorer/companies/1')

--- a/purchasing_test/unit/wexplorer/test_wexplorer.py
+++ b/purchasing_test/unit/wexplorer/test_wexplorer.py
@@ -115,3 +115,27 @@ class TestWexplorer(BaseTestCase):
 
         # test you can't unsubscribe from a nonexistant contract
         self.assert404(self.client.get('/wexplorer/contracts/999/unsubscribe'))
+
+    def test_filter(self):
+        # login as admin user and subscribe to two contracts
+        self.login_user(self.admin_user)
+        self.client.get('/wexplorer/contracts/1/subscribe')
+        self.client.get('/wexplorer/contracts/2/subscribe')
+
+        # filter by contracts associated with Other department
+        self.client.get('/wexplorer/filter?department=Other')
+        self.assertEquals(len(self.get_context_variable('results')), 2)
+
+        # assert innovation and performance has no results
+        self.client.get('/wexplorer/filter?department=Innovation+and+Performance')
+        self.assertEquals(len(self.get_context_variable('results')), 0)
+
+        # assert you must have a department
+        request = self.client.get('/wexplorer/filter')
+        self.assertEquals(request.status_code, 302)
+        self.assert_flashes('You must choose a valid department!', 'alert-danger')
+
+        # assert that the department must be a real department
+        request = self.client.get('/wexplorer/filter?department=FAKEFAKEFAKE')
+        self.assertEquals(request.status_code, 302)
+        self.assert_flashes('You must choose a valid department!', 'alert-danger')


### PR DESCRIPTION
### What Changed
- Added "filter" view where you can see a list of contracts that users from a certain department are watching.
### Issues
- Fixes #10 
### Notes
- #8 must be merged as a dependency before this one is merged.
- It doesn't make a whole lot of sense to go through and categorize everything as "departmental" at this point because we don't have a sense of what the "old" data is. Once we have a finalized spreadsheet for the old data, we can go ahead and input this information.
  - On a related note, I'm not totally sure it makes sense for a contract to have a primary top-level "department" field, but it could definitely be a property on that contract.
### Screecap

![autom8](https://cloud.githubusercontent.com/assets/1957344/7546752/190f406e-f5a7-11e4-8b18-31c301ab40ec.gif)
