### PR TITLE
Text changes to navbar and FAQ

### DIFF
--- a/purchasing/templates/includes/footer.html
+++ b/purchasing/templates/includes/footer.html
@@ -3,7 +3,7 @@
     <div class="col-sm-6 col-sm-offset-3">
       <small>
         <p>
-          Made by <a target="_blank" href="http://www.codeforamerica.org/">Code for America</a> and the <a target="_blank" href="http://pittsburghpa.gov/innovation-performance/home">Pittsburgh Department of Innovation and Performance</a>
+          Made by <a target="_blank" href="http://www.codeforamerica.org/">Code for America</a> and the <a target="_blank" href="http://pittsburghpa.gov/innovation-performance/home">Pittsburgh Department of Innovation and Performance</a>.
         </p>
 
       </small>

--- a/purchasing/templates/includes/nav-login.html
+++ b/purchasing/templates/includes/nav-login.html
@@ -4,11 +4,11 @@
   <li><p class="navbar-text"><a class="navbar-link" href="{{ url_for('admin.index') }}">Admin</a></p></li>
   {% endif %}
   <li><p class="navbar-text"><a class="navbar-link" href="{{ url_for('users.profile') }}">Profile</a></p></li>
-  <li><a class="navbar-link js-signout" href="#"><i class="fa fa-sign-out"></i> Sign Out</a></li>
+  <li><a class="navbar-link js-signout" href="#"><i class="fa fa-sign-out"></i> Sign out</a></li>
 </ul>
 {% else %}
 <ul class="nav navbar-nav navbar-right">
-  <li><p class="navbar-text"><a href="#" class="navbar-link js-signin">Login</a></p></li>
+  <li><p class="navbar-text"><a href="#" class="navbar-link js-signin">City staff login</a></p></li>
 </ul>
 {% endif %}
 

--- a/purchasing/templates/opportunities/front/splash.html
+++ b/purchasing/templates/opportunities/front/splash.html
@@ -23,7 +23,7 @@
     </div>
   </div><!-- /splash-header -->
 
-  <div class="spacer-10"></div>
+  <div class="spacer-30"></div>
 
   <div class="faq-content-container">
     <div class="row">
@@ -34,11 +34,21 @@
 
         <div class="faq-question row">
           <h3><strong>Does the City have special requirements for businesses?</strong></h3>
-          <p>As part of your proposal, you'll be required to send in an current business insurance certificate, and a minority business participation form.</p>
+          <p>When applying for City contracts, your business must have:</p>
+          <ul>
+            <li>A state tax ID from any state in the US. If you'd like to register your business for a Pennsylvania tax ID, you can do so <a href="https://www.pa100.state.pa.us/Registration.htm" target="_blank">here</a>.</li>
+            <li>A federal tax ID number, also known as an EIN (Employer Identification Number). Get one from the IRS <a href="http://www.irs.gov/Businesses/Small-Businesses-&-Self-Employed/Apply-for-an-Employer-Identification-Number-(EIN)-Online" target="_blank">here</a>.</li>
+            </ul>
 
-          <p>Depending on the project, you maybe required to submit bid bonding documents.</p>
+          <p>Some contracts require these additional documents:</p>
+          <ul>
+           <li>An insurance certificate from your insurer, which is used to prove your business can cover liabilities.</li>
+           <li>Bid bonds and performance bonds, which are used to guarantee that contractors who win the contract will accept it and complete it.</li>
+            </ul>
 
-          <p>If your business is minority, woman, or veteran-owned, the City of Pittsburgh will accept current certifications from any government agency. If you aren't currently certified, you can get certified through Allegheny County <a href="http://www.alleghenycounty.us/mwdbe/appidx.aspx" target="_blank">here</a>.</p>
+            <h3><strong>If my business is minority, woman, or veteran-owned, what documentation do I need?</strong></h3>
+
+          <p>The City of Pittsburgh accepts current certifications from any government agency. If you aren't currently certified, you can get certified through Allegheny County <a href="http://www.alleghenycounty.us/mwdbe/appidx.aspx" target="_blank">here</a>.</p>
         </div>
 
         <div class="faq-question row">
@@ -74,7 +84,7 @@
           <p>Email us at <a href="mailto:pittsburgh@codeforamerica.org?Subject=Questions%20for%20FAQ">pittsbugh@codeforamerica.org</a>! We'll add new questions and answers to this page.</p>
         </div>
 
-        <div class="spacer-20"></div>
+        <div class="spacer-30"></div>
 
       </div>
     </div>

--- a/purchasing/templates/opportunities/nav.html
+++ b/purchasing/templates/opportunities/nav.html
@@ -8,20 +8,20 @@
 {% endblock %}
 
 {% block applinks_right %}
-<li><p class="navbar-text"><a href="{{ url_for('opportunities.browse') }}" class="navbar-link">Browse Opportunities</a></p></li>
+<li><p class="navbar-text"><a href="{{ url_for('opportunities.browse') }}" class="navbar-link">Browse opportunities</a></p></li>
 <li><p class="navbar-text"><a href="{{ url_for('opportunities.signup') }}" class="navbar-link">Subscribe</a></p></li>
-<li><p class="navbar-text"><a href="{{ url_for('opportunities.manage') }}" class="navbar-link">Manage Subscriptions</a></p></li>
+<li><p class="navbar-text"><a href="{{ url_for('opportunities.manage') }}" class="navbar-link">Manage subscriptions</a></p></li>
 {% if not current_user.is_anonymous() %}
 <li class="dropdown">
   <a class="btn nav-dropdown-btn dropdown-toggle" data-toggle="dropdown" aria-expanded="false">
     Manage Opportunities
     <span class="caret"></span>
-    <span class="sr-only">Toggle Dropdown</span>
+    <span class="sr-only">Toggle dropdown</span>
   </a>
   <ul class="dropdown-menu" role="menu">
-    <li><a href="{{ url_for('opportunities_admin.new') }}">Add New Opportunity</a></li>
-    <li><a href="{{ url_for('opportunities_admin.pending') }}">View Pending Opportunities</a></li>
-    <li><a href="{{ url_for('opportunities_admin.signups') }}">Download Vendor Subscriptions</a></li>
+    <li><a href="{{ url_for('opportunities_admin.new') }}">Add new opportunity</a></li>
+    <li><a href="{{ url_for('opportunities_admin.pending') }}">View pending opportunities</a></li>
+    <li><a href="{{ url_for('opportunities_admin.signups') }}">Download vendor subscriptions</a></li>
     {% if current_user.is_conductor() %}
     <li><a href="{{ url_for('admin.index') }}" class="navbar-link">Admin</a></li>
     {% endif %}


### PR DESCRIPTION
#### What changed

As noted in #128 (https://github.com/codeforamerica/pittsburgh-purchasing-suite/issues/128):
- Reduced height of splash image
- Changed "Login" in nav bar to "City staff login"
- Created lists of required and sometimes-required documents in FAQ (missing links to insurance certificates and bid bonds; waiting on Law)
#### What's needed
- Nothing
#### Screencap

![screen shot 2015-07-23 at 3 56 16 pm](https://cloud.githubusercontent.com/assets/1178390/8864880/31beed4e-315c-11e5-9a1d-edcb8239f210.png)
![screen shot 2015-07-23 at 3 56 03 pm](https://cloud.githubusercontent.com/assets/1178390/8864881/31bf255c-315c-11e5-8334-58c1b8e34918.png)
