### PR TITLE
3 of 3 Beacon email changes

### DIFF
--- a/purchasing/opportunities/admin/views.py
+++ b/purchasing/opportunities/admin/views.py
@@ -23,6 +23,7 @@ from purchasing.opportunities.models import (
 )
 from purchasing.users.models import User, Role
 from purchasing.opportunities.util import get_categories, fix_form_categories
+from purchasing.notifications import Notification
 
 blueprint = Blueprint(
     'opportunities_admin', __name__, url_prefix='/beacon/admin',
@@ -199,6 +200,21 @@ def publish(opportunity_id):
         opportunity.is_public = True
         db.session.commit()
         flash('Opportunity successfully published!', 'alert-success')
+
+        opp_categories = [i.id for i in opportunity.categories]
+
+        vendors = Vendor.query.filter(
+            Vendor.categories.any(Category.id.in_(opp_categories))
+        ).all()
+
+        Notification(
+            to_email=[i.email for i in vendors],
+            subject='A new City of Pittsburgh opportunity from Beacon!',
+            html_template='opportunities/emails/newopp.html',
+            txt_template='opportunities/emails/newopp.txt',
+            opportunity=opportunity
+        ).send(multi=True)
+
         return redirect(url_for('opportunities_admin.pending'))
     abort(404)
 

--- a/purchasing/opportunities/admin/views.py
+++ b/purchasing/opportunities/admin/views.py
@@ -201,19 +201,20 @@ def publish(opportunity_id):
         db.session.commit()
         flash('Opportunity successfully published!', 'alert-success')
 
-        opp_categories = [i.id for i in opportunity.categories]
+        if opportunity.is_advertised:
+            opp_categories = [i.id for i in opportunity.categories]
 
-        vendors = Vendor.query.filter(
-            Vendor.categories.any(Category.id.in_(opp_categories))
-        ).all()
+            vendors = Vendor.query.filter(
+                Vendor.categories.any(Category.id.in_(opp_categories))
+            ).all()
 
-        Notification(
-            to_email=[i.email for i in vendors],
-            subject='A new City of Pittsburgh opportunity from Beacon!',
-            html_template='opportunities/emails/newopp.html',
-            txt_template='opportunities/emails/newopp.txt',
-            opportunity=opportunity
-        ).send(multi=True)
+            Notification(
+                to_email=[i.email for i in vendors],
+                subject='A new City of Pittsburgh opportunity from Beacon!',
+                html_template='opportunities/emails/newopp.html',
+                txt_template='opportunities/emails/newopp.txt',
+                opportunity=opportunity
+            ).send(multi=True)
 
         return redirect(url_for('opportunities_admin.pending'))
     abort(404)

--- a/purchasing/opportunities/front/views.py
+++ b/purchasing/opportunities/front/views.py
@@ -216,14 +216,15 @@ def signup_for_opp(form, user, opportunity, multi=False):
 
     db.session.commit()
 
-    Notification(
-        to_email=vendor.email,
-        subject='Subscription confirmation from Beacon',
-        html_template='opportunities/emails/oppselected.html',
-        txt_template='opportunities/emails/oppselected.txt',
-        opportunities=email_opportunities
-    ).send()
-    return True
+    if opportunity.is_advertised:
+        Notification(
+            to_email=vendor.email,
+            subject='Subscription confirmation from Beacon',
+            html_template='opportunities/emails/oppselected.html',
+            txt_template='opportunities/emails/oppselected.txt',
+            opportunities=email_opportunities
+        ).send()
+        return True
 
 @blueprint.route('/opportunities', methods=['GET', 'POST'])
 def browse():

--- a/purchasing/opportunities/front/views.py
+++ b/purchasing/opportunities/front/views.py
@@ -216,15 +216,15 @@ def signup_for_opp(form, user, opportunity, multi=False):
 
     db.session.commit()
 
-    if opportunity.is_advertised:
-        Notification(
-            to_email=vendor.email,
-            subject='Subscription confirmation from Beacon',
-            html_template='opportunities/emails/oppselected.html',
-            txt_template='opportunities/emails/oppselected.txt',
-            opportunities=email_opportunities
-        ).send()
-        return True
+    Notification(
+        to_email=vendor.email,
+        subject='Subscription confirmation from Beacon',
+        html_template='opportunities/emails/oppselected.html',
+        txt_template='opportunities/emails/oppselected.txt',
+        opportunities=email_opportunities
+    ).send()
+
+    return True
 
 @blueprint.route('/opportunities', methods=['GET', 'POST'])
 def browse():

--- a/purchasing/opportunities/front/views.py
+++ b/purchasing/opportunities/front/views.py
@@ -229,8 +229,7 @@ def signup_for_opp(form, user, opportunity, multi=False):
 def browse():
     '''Browse available opportunities
     '''
-    active, upcoming = [], []
-    visible_active, visible_upcoming = 0, 0
+    _open, upcoming = [], []
 
     signup_form = init_form(OpportunitySignupForm)
     if signup_form.validate_on_submit():
@@ -246,20 +245,15 @@ def browse():
     ).all()
 
     for opportunity in opportunities:
-        if opportunity.is_published():
-            active.append(opportunity)
-            if not current_user.is_anonymous() or opportunity.is_public:
-                visible_active += 1
-        else:
+        if opportunity.is_open:
+            _open.append(opportunity)
+        elif opportunity.is_upcoming:
             upcoming.append(opportunity)
-            if not current_user.is_anonymous() or opportunity.is_public:
-                visible_upcoming += 1
 
     return render_template(
         'opportunities/browse.html', opportunities=opportunities,
-        active=active, upcoming=upcoming, current_user=current_user,
-        signup_form=signup_form, visible_active=visible_active,
-        visible_upcoming=visible_upcoming
+        _open=_open, upcoming=upcoming, current_user=current_user,
+        signup_form=signup_form
     )
 
 @blueprint.route('/opportunities/<int:opportunity_id>', methods=['GET', 'POST'])

--- a/purchasing/opportunities/front/views.py
+++ b/purchasing/opportunities/front/views.py
@@ -176,6 +176,7 @@ def init_form(form):
     return form(obj=data)
 
 def signup_for_opp(form, user, opportunity, multi=False):
+    email_opportunities = []
     if opportunity is None or (isinstance(opportunity, list) and len(opportunity) == 0):
         form.errors['opportunities'] = ['You must select at least one opportunity!']
         return False
@@ -204,14 +205,24 @@ def signup_for_opp(form, user, opportunity, multi=False):
                 form.errors['opportunities'] = ['That\'s not a valid choice.']
                 return False
             vendor.opportunities.add(_opp)
+            email_opportunities.append(_opp)
     else:
         vendor.opportunities.add(opportunity)
+        email_opportunities.append(opportunity)
 
     if form.data.get('also_categories'):
         # TODO -- add support for categories
         pass
 
     db.session.commit()
+
+    Notification(
+        to_email=vendor.email,
+        subject='Subscription confirmation from Beacon',
+        html_template='opportunities/emails/oppselected.html',
+        txt_template='opportunities/emails/oppselected.txt',
+        opportunities=email_opportunities
+    ).send()
     return True
 
 @blueprint.route('/opportunities', methods=['GET', 'POST'])

--- a/purchasing/opportunities/models.py
+++ b/purchasing/opportunities/models.py
@@ -119,15 +119,14 @@ class Opportunity(Model):
         '''Returns the month/year based on planned_open
         '''
         if self.is_published():
-            return self.planned_open.strftime('%Y-%m-%d')
+            return self.planned_open.strftime('%B %d, %Y')
         return self.planned_open.strftime('%B %Y')
 
     def estimate_deadline(self):
         '''
         '''
-        if self.is_expired():
-            return self.planned_deadline.strftime('%Y-%m-%d')
-        return self.planned_deadline.strftime('%B %Y')
+        return self.planned_deadline.strftime('%B %d, %Y')
+        
 
     def get_needed_documents(self):
         return RequiredBidDocument.query.filter(

--- a/purchasing/settings.py
+++ b/purchasing/settings.py
@@ -53,7 +53,7 @@ class DevConfig(Config):
     ASSETS_DEBUG = True
     UPLOAD_S3 = False
     UPLOAD_DESTINATION = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir, 'uploads'))
-    MAIL_SUPPRESS_SEND = True
+    MAIL_SUPPRESS_SEND = False
 
 class TestConfig(Config):
     TESTING = True

--- a/purchasing/templates/opportunities/admin/opportunity.html
+++ b/purchasing/templates/opportunities/admin/opportunity.html
@@ -145,7 +145,7 @@
             </button>
             <ul class="dropdown-menu submit-dropdown">
               <li><a href="#" onclick="$('#save_type').val('save'); $('#js-opportunity-form').submit()">Save as draft</a></li>
-              <li><a href="#" onclick="$('#save_type').val('publish'); $('#js-opportunity-form').submit()">Save and make public</a></li>
+              <li><a href="#" onclick="$('#save_type').val('publish'); $('#js-opportunity-form').submit()">Save and publish on Advertise Date</a></li>
             </ul>
           </div>
         </div>

--- a/purchasing/templates/opportunities/admin/pending.html
+++ b/purchasing/templates/opportunities/admin/pending.html
@@ -5,10 +5,11 @@
 <div class="container">
   <div class="row">
     <div class="col-md-8 col-md-offset-2">
+      <div class="spacer-20"></div>
       {% include "includes/flashes.html" %}
 
-      <h3>Pending Opportunities</h3>
-      <p>Opportunities pending approval from OMB.</p>
+      <h3><strong>Opportunities awaiting OMB approval</strong></h3>
+      <div class="spacer-20"></div>
 
       {% for opportunity in opportunities %}
       <div class="pending-opportunity">
@@ -23,11 +24,11 @@
                 <div class="pull-right">
                 {% if opportunity.can_edit(current_user) %}
                 <a class="pending-opportunity-edit" href="{{ url_for('opportunities_admin.edit', opportunity_id=opportunity.id) }}">
-                  <strong>Edit this opportunity</strong>
+                  <strong>Edit</strong>
                 </a>
                 {% endif %}
                 {% if not current_user.is_anonymous() and current_user.is_conductor() %}
-                  <a href="{{ url_for('opportunities_admin.publish', opportunity_id=opportunity.id) }}" class="btn btn-primary">Publish</a>
+                  <a href="{{ url_for('opportunities_admin.publish', opportunity_id=opportunity.id) }}" class="btn btn-primary">Publish on {{ opportunity.planned_open.strftime('%m/%d/%y') }}</a>
                 {% endif %}
                 </div>
               </div>
@@ -39,16 +40,16 @@
 
             <div class="row">
               <div class="col-xs-4">
-                <h4>Beacon Post Date</h4>
-                <p>{{ opportunity.planned_open.strftime('%Y-%m-%d') }}</p>
+                <h4>Planned Advertise Date</h4>
+                <p>{{ opportunity.planned_open.strftime('%m/%d/%y') }}</p>
               </div>
               <div class="col-xs-4">
                 <h4>Planned Open Date</h4>
-                <p>{{ opportunity.planned_deadline.strftime('%Y-%m-%d') }}</p>
+                <p>{{ opportunity.planned_deadline.strftime('%m/%d/%y') }}</p>
               </div>
               <div class="col-xs-4">
                 <h4>Planned Deadline</h4>
-                <p>{{ opportunity.planned_deadline.strftime('%Y-%m-%d') }}</p>
+                <p>{{ opportunity.planned_deadline.strftime('%m/%d/%y') }}</p>
               </div>
             </div><!-- dates -->
 

--- a/purchasing/templates/opportunities/browse.html
+++ b/purchasing/templates/opportunities/browse.html
@@ -15,47 +15,33 @@
 
         <h3><strong>Currently accepting proposals</strong></h3>
 
-        {% if visible_active > 0 %}
+        {% if _open|length > 0 %}
         <div class="table-responsive">
           <table class="table table-striped">
             <thead>
               <tr>
                 <th>Select</th>
-                <th>Opportunity Details</th>
+                <th>Opportunity</th>
                 <th>Department</th>
                 <th>Deadline</th>
                 {% if not current_user.is_anonymous() %}
-                <th>Edit this contract</th>
-                <th>Public</th>
+                <th>Edit </th>
                 {% endif %}
               </tr>
             </thead>
             <tbody>
-              {% for opportunity in active %}
-              {% if not current_user.is_anonymous() or opportunity.is_public %}
+              {% for opportunity in _open %}
               <tr>
                 <td><input type="checkbox" name="opportunity" value="{{ opportunity.id }}"></td>
                 <td><a href="{{ url_for('opportunities.detail', opportunity_id=opportunity.id) }}">{{ opportunity.title }}</a></td>
                 <td>{{ opportunity.department }}</td>
-                <td>{{ opportunity.planned_deadline.strftime('%Y-%m-%d') }}</td>
+                <td>{{ opportunity.planned_deadline.strftime('%B %d, %Y') }}</td>
                 {% if opportunity.can_edit(current_user) %}
-                <td><a href="{{ url_for('opportunities_admin.edit', opportunity_id=opportunity.id) }}">Edit</a></td>
+                <td><a href="{{ url_for('opportunities_admin.edit', opportunity_id=opportunity.id) }}">Edit this</a></td>
                 {% elif not current_user.is_anonymous() %}
                 <td><i class="fa fa-minus"></i></td>
                 {% endif %}
-                {% if not current_user.is_anonymous() %}
-                  {% if opportunity.is_public %}
-                  <td>
-                    <i class="fa fa-eye" data-toggle="tooltip" title="Visible to the public"></i>
-                  </td>
-                  {% else %}
-                  <td>
-                    <i class="fa fa-eye-slash" data-toggle="tooltip" title="Hidden from the public"></i>
-                  </td>
-                  {% endif %}
-                {% endif %}
               </tr>
-              {% endif %}
               {% endfor %}
             </tbody>
           </table>
@@ -69,7 +55,7 @@
 
         <h3><strong>Upcoming</strong></h3>
 
-        {% if visible_upcoming > 0 %}
+        {% if upcoming|length > 0 %}
         <div class="table-responsive">
           <table class="table table-striped">
             <thead>
@@ -80,35 +66,21 @@
                 <th>Estimated Open Date</th>
                 {% if not current_user.is_anonymous() %}
                 <th>Edit this contract</th>
-                <th>Public</th>
                 {% endif %}
               </tr>
             </thead>
             <tbody>
               {% for opportunity in upcoming %}
-              {% if not current_user.is_anonymous() or opportunity.is_public %}
               <tr>
                 <td><input type="checkbox" name="opportunity" value="{{ opportunity.id }}"></td>
                 <td><a href="{{ url_for('opportunities.detail', opportunity_id=opportunity.id) }}">{{ opportunity.title }}</a></td>
                 <td>{{ opportunity.department }}</td>
-                <td>{{ opportunity.planned_deadline.strftime('%Y-%m-%d') }}</td>
+                <td>{{ opportunity.planned_deadline.strftime('%B %d, %Y') }}</td>
                 {% if opportunity.can_edit(current_user) %}
                 <td><a href="{{ url_for('opportunities_admin.edit', opportunity_id=opportunity.id) }}">Edit</a></td>
                 {% elif not current_user.is_anonymous() %}
                 <i class="fa fa-minus"></i>
                 {% endif %}
-                {% if not current_user.is_anonymous() %}
-                  {% if opportunity.is_public %}
-                  <td>
-                    <i class="fa fa-eye" data-toggle="tooltip" title="Visible to the public"></i>
-                  </td>
-                  {% else %}
-                  <td>
-                    <i class="fa fa-eye-slash" data-toggle="tooltip" title="Hidden from the public"></i>
-                  </td>
-                  {% endif %}
-                {% endif %}
-              {% endif %}
               </tr>
               {% endfor %}
             </tbody>
@@ -120,7 +92,7 @@
 
         {% endif %}
 
-        {% if active|length > 0 or upcoming|length > 0 %}
+        {% if _open|length > 0 or upcoming|length > 0 %}
 
           <div class="spacer-20"></div>
           <h4>Subscribe to selected opportunities</h4>

--- a/purchasing/templates/opportunities/browse.html
+++ b/purchasing/templates/opportunities/browse.html
@@ -37,7 +37,7 @@
                 <td>{{ opportunity.department }}</td>
                 <td>{{ opportunity.planned_deadline.strftime('%B %d, %Y') }}</td>
                 {% if opportunity.can_edit(current_user) %}
-                <td><a href="{{ url_for('opportunities_admin.edit', opportunity_id=opportunity.id) }}">Edit this</a></td>
+                <td><a href="{{ url_for('opportunities_admin.edit', opportunity_id=opportunity.id) }}">Edit</a></td>
                 {% elif not current_user.is_anonymous() %}
                 <td><i class="fa fa-minus"></i></td>
                 {% endif %}

--- a/purchasing/templates/opportunities/browse.html
+++ b/purchasing/templates/opportunities/browse.html
@@ -14,7 +14,7 @@
         {% if not current_user.is_anonymous() %}
            <div class="alert alert-warning alert-dismissible" role="alert">
            <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-              Looking for an opportunity submitted for approval? Check the <a href="">pending opportunities page</a>.
+              Looking for an opportunity submitted for approval? Check the <a href="{{ url_for('opportunities_admin.pending') }}">pending opportunities page</a>.
           </div>
         {% endif %}
 
@@ -114,3 +114,6 @@
 </div>
 
 {% endblock %}
+
+<div class="spacer-50"></div>
+

--- a/purchasing/templates/opportunities/browse.html
+++ b/purchasing/templates/opportunities/browse.html
@@ -9,7 +9,14 @@
 
       <form class="form form-horizontal" method="POST" action="#">
 
-        <div class="spacer-20"></div>
+      <div class="spacer-20"></div>
+
+        {% if not current_user.is_anonymous() %}
+           <div class="alert alert-warning alert-dismissible" role="alert">
+           <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+              Looking for an opportunity submitted for approval? Check the <a href="">pending opportunities page</a>.
+          </div>
+        {% endif %}
 
         <h4>All Opportunities</h4>
 

--- a/purchasing/templates/opportunities/browse.html
+++ b/purchasing/templates/opportunities/browse.html
@@ -32,12 +32,12 @@
             <tbody>
               {% for opportunity in _open %}
               <tr>
-                <td><input type="checkbox" name="opportunity" value="{{ opportunity.id }}"></td>
-                <td><a href="{{ url_for('opportunities.detail', opportunity_id=opportunity.id) }}">{{ opportunity.title }}</a></td>
-                <td>{{ opportunity.department }}</td>
-                <td>{{ opportunity.planned_deadline.strftime('%B %d, %Y') }}</td>
+                <td class="col-md-1"><input type="checkbox" name="opportunity" value="{{ opportunity.id }}"></td>
+                <td class="col-md-5"><a href="{{ url_for('opportunities.detail', opportunity_id=opportunity.id) }}">{{ opportunity.title }}</a></td>
+                <td class="col-md-3">{{ opportunity.department }}</td>
+                <td class="col-md-2">{{ opportunity.planned_deadline.strftime('%m/%d/%y') }}</td>
                 {% if opportunity.can_edit(current_user) %}
-                <td><a href="{{ url_for('opportunities_admin.edit', opportunity_id=opportunity.id) }}">Edit</a></td>
+                <td class="col-md-2"><a href="{{ url_for('opportunities_admin.edit', opportunity_id=opportunity.id) }}">Edit</a></td>
                 {% elif not current_user.is_anonymous() %}
                 <td><i class="fa fa-minus"></i></td>
                 {% endif %}
@@ -53,7 +53,7 @@
 
         {% endif %}
 
-        <h3><strong>Upcoming</strong></h3>
+        <h3><strong>Upcoming opportunities</strong></h3>
 
         {% if upcoming|length > 0 %}
         <div class="table-responsive">
@@ -63,19 +63,19 @@
                 <th>Select</th>
                 <th>Opportunity</th>
                 <th>Department</th>
-                <th>Estimated Open Date</th>
+                <th>Estimated open</th>
                 {% if not current_user.is_anonymous() %}
-                <th>Edit this contract</th>
+                <th>Edit</th>
                 {% endif %}
               </tr>
             </thead>
             <tbody>
               {% for opportunity in upcoming %}
               <tr>
-                <td><input type="checkbox" name="opportunity" value="{{ opportunity.id }}"></td>
-                <td><a href="{{ url_for('opportunities.detail', opportunity_id=opportunity.id) }}">{{ opportunity.title }}</a></td>
-                <td>{{ opportunity.department }}</td>
-                <td>{{ opportunity.planned_deadline.strftime('%B %d, %Y') }}</td>
+                <td class="col-md-1"><input type="checkbox" name="opportunity" value="{{ opportunity.id }}"></td>
+                <td class="col-md-5"><a href="{{ url_for('opportunities.detail', opportunity_id=opportunity.id) }}">{{ opportunity.title }}</a></td>
+                <td class="col-md-3">{{ opportunity.department }}</td>
+                <td class="col-md-2">{{ opportunity.planned_deadline.strftime('%m/%d/%y') }}</td>
                 {% if opportunity.can_edit(current_user) %}
                 <td><a href="{{ url_for('opportunities_admin.edit', opportunity_id=opportunity.id) }}">Edit</a></td>
                 {% elif not current_user.is_anonymous() %}

--- a/purchasing/templates/opportunities/emails/base.html
+++ b/purchasing/templates/opportunities/emails/base.html
@@ -562,7 +562,7 @@
 
                                 <td valign="top" class="mcnTextContent" style="padding: 9px 18px;font-size: 18px;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;color: #606060;font-family: Helvetica;line-height: 125%;text-align: left;">
 
-                                  Pittsburgh Opportunities
+                                  Beacon
                                 </td>
                               </tr>
                             </tbody></table>

--- a/purchasing/templates/opportunities/emails/base.html
+++ b/purchasing/templates/opportunities/emails/base.html
@@ -561,8 +561,7 @@
                               <tbody><tr>
 
                                 <td valign="top" class="mcnTextContent" style="padding: 9px 18px;font-size: 18px;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;color: #606060;font-family: Helvetica;line-height: 125%;text-align: left;">
-
-                                  Beacon
+                                A new message from Beacon!
                                 </td>
                               </tr>
                             </tbody></table>
@@ -624,7 +623,7 @@
                           </td>
                         </tr>
                       </tbody>
-                    </table><table border="0" cellpadding="0" cellspacing="0" width="100%" class="mcnBoxedTextBlock" style="border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
+                    </table><!-- <table border="0" cellpadding="0" cellspacing="0" width="100%" class="mcnBoxedTextBlock" style="border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
                     <tbody class="mcnBoxedTextBlockOuter">
                       <tr>
                         <td valign="top" class="mcnBoxedTextBlockInner" style="mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
@@ -637,7 +636,7 @@
                                 <table border="0" cellpadding="18" cellspacing="0" class="mcnTextContentContainer" width="100%" style="border: 1px solid #999999;background-color: #F2F2F2;border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
                                   <tbody><tr>
                                     <td valign="top" class="mcnTextContent" style="mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;color: #606060;font-family: Helvetica;font-size: 15px;line-height: 150%;text-align: left;">
-                                      {% block panel %}{% endblock %}
+                                     
                                     </td>
                                   </tr>
                                 </tbody></table>
@@ -648,7 +647,7 @@
                         </td>
                       </tr>
                     </tbody>
-                  </table><table border="0" cellpadding="0" cellspacing="0" width="100%" class="mcnTextBlock" style="border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
+                  </table> --><table border="0" cellpadding="0" cellspacing="0" width="100%" class="mcnTextBlock" style="border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
                   <tbody class="mcnTextBlockOuter">
                     <tr>
                       <td valign="top" class="mcnTextBlockInner" style="mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">

--- a/purchasing/templates/opportunities/emails/base.html
+++ b/purchasing/templates/opportunities/emails/base.html
@@ -623,31 +623,7 @@
                           </td>
                         </tr>
                       </tbody>
-                    </table><!-- <table border="0" cellpadding="0" cellspacing="0" width="100%" class="mcnBoxedTextBlock" style="border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
-                    <tbody class="mcnBoxedTextBlockOuter">
-                      <tr>
-                        <td valign="top" class="mcnBoxedTextBlockInner" style="mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
-
-                          <table align="left" border="0" cellpadding="0" cellspacing="0" width="600" class="mcnBoxedTextContentContainer" style="border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
-                            <tbody><tr>
-
-                              <td style="padding-top: 9px;padding-left: 18px;padding-bottom: 9px;padding-right: 18px;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
-
-                                <table border="0" cellpadding="18" cellspacing="0" class="mcnTextContentContainer" width="100%" style="border: 1px solid #999999;background-color: #F2F2F2;border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
-                                  <tbody><tr>
-                                    <td valign="top" class="mcnTextContent" style="mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;color: #606060;font-family: Helvetica;font-size: 15px;line-height: 150%;text-align: left;">
-                                     
-                                    </td>
-                                  </tr>
-                                </tbody></table>
-                              </td>
-                            </tr>
-                          </tbody></table>
-
-                        </td>
-                      </tr>
-                    </tbody>
-                  </table> --><table border="0" cellpadding="0" cellspacing="0" width="100%" class="mcnTextBlock" style="border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
+                    </table><table border="0" cellpadding="0" cellspacing="0" width="100%" class="mcnTextBlock" style="border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
                   <tbody class="mcnTextBlockOuter">
                     <tr>
                       <td valign="top" class="mcnTextBlockInner" style="mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">

--- a/purchasing/templates/opportunities/emails/newopp.html
+++ b/purchasing/templates/opportunities/emails/newopp.html
@@ -6,7 +6,7 @@
 <p>We’re pleased to announce a new opportunity to work with the City: <a href="{{ url_for('opportunities.detail', opportunity_id=opportunity.id, _external=True) }}">{{ opportunity.title }}</a>.  It could be a great fit for your business! 
 </p>
 
-<p>We invite you to <a href="{{ url_for('opportunities.detail', opportunity_id=opportunity.id, _external=True) }}">take a look</a> and send in a proposal if you’re interested! The window to send in proposals opens on {{ opportunity.planned_open }} and closes on {{ opportunity.planned_deadline }}.
+<p>We invite you to <a href="{{ url_for('opportunities.detail', opportunity_id=opportunity.id, _external=True) }}">take a look</a> and send in a proposal if you’re interested! The window to send in proposals opens on {{ opportunity.estimate_open() }} and closes on {{ opportunity.estimate_deadline() }}.
 </p>
 <p>Have a question? Click on the link at the end of this message to send us an email, and we'll get back to you as soon as we can.</p>
 

--- a/purchasing/templates/opportunities/emails/newopp.html
+++ b/purchasing/templates/opportunities/emails/newopp.html
@@ -1,0 +1,22 @@
+{% extends "opportunities/emails/base.html" %}
+
+{% block content %}
+<h2>A new City of Pittsburgh opportunity!</h2>
+<p>We’re pleased to announce a new opportunity to work with the City: <a href="{{ url_for('opportunities.detail', opportunity_id=opportunity.id), _external=True }}">{{ opportunity.title }}</a>. It falls under 
+    {% for category in opportunity.categories %}
+          {% if loop.index <= 3 %}{{ category.category_friendly_name }},{% endif %}
+    {% endfor %}
+        and {{ opportunity.categories|length - 3 }} more categories you selected. It could be a great fit for your business! 
+</p>
+<p>We invite you to <a href="{{ url_for('opportunities.detail', opportunity_id=opportunity.id), _external=True }}">take a look</a> and send in a proposal if you’re interested! The window to send in proposals opens on {{ opportunity.planned_open }} and closes on {{ opportuninty.planned_deadline }}.
+</p>
+{% endblock %}
+
+<p>Thanks,<br>
+The Beacon team
+</p>
+{% endblock %}
+
+{% block footer %}
+<p><a href="{{ url_for('opportunities.manage', _external=True) }}">Manage your subscription</a> | <a href="mailto:pittsburgh@codeforamerica.org?Subject=Feedback%20from%20Email">Questions? Email us</a>
+{% endblock %}

--- a/purchasing/templates/opportunities/emails/newopp.html
+++ b/purchasing/templates/opportunities/emails/newopp.html
@@ -2,15 +2,15 @@
 
 {% block content %}
 <h2>A new City of Pittsburgh opportunity!</h2>
-<p>We’re pleased to announce a new opportunity to work with the City: <a href="{{ url_for('opportunities.detail', opportunity_id=opportunity.id), _external=True }}">{{ opportunity.title }}</a>. It falls under 
+<p>We’re pleased to announce a new opportunity to work with the City: <a href="{{ url_for('opportunities.detail', opportunity_id=opportunity.id, _external=True) }}">{{ opportunity.title }}</a>. It falls under 
     {% for category in opportunity.categories %}
           {% if loop.index <= 3 %}{{ category.category_friendly_name }},{% endif %}
     {% endfor %}
         and {{ opportunity.categories|length - 3 }} more categories you selected. It could be a great fit for your business! 
 </p>
-<p>We invite you to <a href="{{ url_for('opportunities.detail', opportunity_id=opportunity.id), _external=True }}">take a look</a> and send in a proposal if you’re interested! The window to send in proposals opens on {{ opportunity.planned_open }} and closes on {{ opportuninty.planned_deadline }}.
+<p>We invite you to <a href="{{ url_for('opportunities.detail', opportunity_id=opportunity.id, _external=True) }}">take a look</a> and send in a proposal if you’re interested! The window to send in proposals opens on {{ opportunity.planned_open }} and closes on {{ opportunity.planned_deadline }}.
 </p>
-{% endblock %}
+<p>Have a question? Click on the link at the end of this message to send us an email, and we'll get back to you as soon as we can.</p>
 
 <p>Thanks,<br>
 The Beacon team

--- a/purchasing/templates/opportunities/emails/newopp.txt
+++ b/purchasing/templates/opportunities/emails/newopp.txt
@@ -1,6 +1,6 @@
 We’re pleased to announce a new opportunity to work with the City: {{ url_for('opportunities.detail', opportunity_id=opportunity.id), _external=True }} It could be a great fit for your business! 
 
-WWe invite you to take a look and send in a proposal if you’re interested! The window to send in proposals opens on {{ opportunity.planned_open }} and closes on {{ opportuninty.planned_deadline }}
+We invite you to take a look and send in a proposal if you’re interested! The window to send in proposals opens on {{ opportunity.planned_open }} and closes on {{ opportunity.planned_deadline }}
 
 Thanks,
 The Beacon Team

--- a/purchasing/templates/opportunities/emails/newopp.txt
+++ b/purchasing/templates/opportunities/emails/newopp.txt
@@ -1,0 +1,6 @@
+We’re pleased to announce a new opportunity to work with the City: {{ url_for('opportunities.detail', opportunity_id=opportunity.id), _external=True }} It could be a great fit for your business! 
+
+WWe invite you to take a look and send in a proposal if you’re interested! The window to send in proposals opens on {{ opportunity.planned_open }} and closes on {{ opportuninty.planned_deadline }}
+
+Thanks,
+The Beacon Team

--- a/purchasing/templates/opportunities/emails/newopp.txt
+++ b/purchasing/templates/opportunities/emails/newopp.txt
@@ -1,6 +1,6 @@
-We’re pleased to announce a new opportunity to work with the City: {{ url_for('opportunities.detail', opportunity_id=opportunity.id), _external=True }} It could be a great fit for your business! 
+We’re pleased to announce a new opportunity to work with the City: {{ url_for('opportunities.detail', opportunity_id=opportunity.id, _external=True) }} It could be a great fit for your business! 
 
-We invite you to take a look and send in a proposal if you’re interested! The window to send in proposals opens on {{ opportunity.planned_open }} and closes on {{ opportunity.planned_deadline }}
+We invite you to take a look and send in a proposal if you’re interested! The window to send in proposals opens on {{ opportunity.estimate_open() }} and closes on {{ opportunity.estimate_deadline() }}.
 
 Thanks,
 The Beacon Team

--- a/purchasing/templates/opportunities/emails/oppselected.html
+++ b/purchasing/templates/opportunities/emails/oppselected.html
@@ -1,19 +1,17 @@
 {% extends "opportunities/emails/base.html" %}
 
 {% block content %}
-<h2>Your new subscription is confirmed</h2>
-{% endblock %}
+<h2>Thanks for subscribing!</h2>
 
-{% block panel %}
-<p>Thanks for subscribing to:</p>
+<p>Hi there! You've successfully subscribed to updates about:</p>
  {% for opportunity in opportunities %}
  <ul>
-  <li><a href="{{ url_for('opportunities.detail', opportunity_id=opportunity.id), _external=True }}">{{ opportunity.title }}</a></li>
+  <li><a href="{{ url_for('opportunities.detail', opportunity_id=opportunity.id, _external=True) }}">{{ opportunity.title }}</a></li>
 </ul>
   {% endfor %}  
   <p>If you’re interested, we invite you to send in a proposal! Stay tuned for reminders about deadlines and opportunities to send in questions.
 </p>
-{% endblock %}
+<p>Have a question? Click on the link at the end of this message to send us an email, and we'll get back to you as soon as we can.</p>
 
 <p>Best,<br>
     - The Beacon team

--- a/purchasing/templates/opportunities/emails/oppselected.html
+++ b/purchasing/templates/opportunities/emails/oppselected.html
@@ -1,0 +1,25 @@
+{% extends "opportunities/emails/base.html" %}
+
+{% block content %}
+<h2>Your new subscription is confirmed</h2>
+{% endblock %}
+
+{% block panel %}
+<p>Thanks for subscribing to:</p>
+ {% for opportunity in opportunities %}
+ <ul>
+  <li><a href="{{ url_for('opportunities.detail', opportunity_id=opportunity.id), _external=True }}">{{ opportunity.title }}</a></li>
+</ul>
+  {% endfor %}  
+  <p>If you’re interested, we invite you to send in a proposal! Stay tuned for reminders about deadlines and opportunities to send in questions.
+</p>
+{% endblock %}
+
+<p>Best,<br>
+    - The Beacon team
+</p>
+{% endblock %}
+
+{% block footer %}
+<p><a href="{{ url_for('opportunities.manage', _external=True) }}">Manage your subscription</a> | <a href="mailto:pittsburgh@codeforamerica.org?Subject=Feedback%20from%20Email">Questions? Email us</a>
+{% endblock %}

--- a/purchasing/templates/opportunities/emails/oppselected.txt
+++ b/purchasing/templates/opportunities/emails/oppselected.txt
@@ -1,0 +1,11 @@
+Your new Beacon subscription is confirmed.
+
+Thanks for subscribing to: 
+{% for opportunity in opportunities %}
+- {{ opportunity.title }}
+{% endfor %}  
+
+If you’re interested, we invite you to send in a proposal! Stay tuned for reminders about deadlines and opportunities to send in questions.
+
+Best,
+The Beacon Team

--- a/purchasing/templates/opportunities/emails/oppselected.txt
+++ b/purchasing/templates/opportunities/emails/oppselected.txt
@@ -2,10 +2,10 @@ Your new Beacon subscription is confirmed.
 
 Thanks for subscribing to: 
 {% for opportunity in opportunities %}
-- {{ opportunity.title }}
+- {{ opportunity.title }}: {{ url_for('opportunities.detail', opportunity_id=opportunity.id, _external=True) }}">
 {% endfor %}  
 
-If you’re interested, we invite you to send in a proposal! Stay tuned for reminders about deadlines and opportunities to send in questions.
+If you’re interested, we invite you to take a look and send in a proposal! Stay tuned for reminders about deadlines and opportunities to send in questions.
 
 Best,
 The Beacon Team

--- a/purchasing/templates/opportunities/emails/signup.html
+++ b/purchasing/templates/opportunities/emails/signup.html
@@ -3,7 +3,7 @@
 {% block content %}
 <h2>Hello and welcome to Beacon!</h2>
 <p>Thanks for subscribing for updates about opportunities to do business with the City of Pittsburgh! We hope you'll find an opportunity that's right for your business.</p>
-{% endblock %}
+
 
 {% if categories|length > 20 %}
 <p>You've signed up to receive notifications about {{ categories|length }} categories. You can view all of them <a href="{{ url_for('opportunities.manage', _external=True) }}">here.</a></p>
@@ -14,6 +14,7 @@
   <li>{{ category.subcategory }}</li>
   {% endfor %}
 </ul>
+{% endif %}
 
 <p>Every 2 weeks, we’ll send a short summary of all opportunities that have been posted, so you don’t miss out on potential business. 
 </p>

--- a/purchasing/templates/opportunities/emails/signup.html
+++ b/purchasing/templates/opportunities/emails/signup.html
@@ -1,14 +1,15 @@
 {% extends "opportunities/emails/base.html" %}
 
 {% block content %}
-<h2>Thank you for subscribing for updates about Pittsburgh Opportunities!</h2>
+<h2>Hello and welcome to Beacon!</h2>
+<p>Thanks for subscribing for updates about opportunities to do business with the City of Pittsburgh! We hope you'll find an opportunity that's right for your business.</p>
 {% endblock %}
 
 {% block panel %}
 {% if categories|length > 20 %}
-<p>You have signed up to receive notifications about {{ categories|length }} categories!</p>
+<p>You've signed up to receive notifications about {{ categories|length }} categories. You can view all of them <a href="{{ url_for('opportunities.manage', _external=True) }}">here.</a></p>
 {% else %}
-<p>You have signed up to receive notifications about the following categories:</p>
+<p>You've signed up to receive notifications about the following categories:</p>
 <ul>
   {% for category in categories %}
   <li>{{ category.subcategory }}</li>
@@ -17,6 +18,14 @@
 {% endif %}
 {% endblock %}
 
+{% block content %}
+<p>Every 2 weeks, we’ll send a short summary of all opportunities that have been posted, so you don’t miss out on potential business. 
+</p>
+<p>Thanks,<br>
+    - The Beacon team
+</p>
+{% endblock %}
+
 {% block footer %}
-<a href="{{ url_for('opportunities.manage', _external=True) }}">Manage your notification settings</a> | <a href="mailto:pittsburgh@codeforamerica.org?Subject=Feedback%20from%20Email">Send feedback</a>
+<p><a href="{{ url_for('opportunities.manage', _external=True) }}">Manage your subscription</a> | <a href="mailto:pittsburgh@codeforamerica.org?Subject=Feedback%20from%20Email">Questions? Email us</a>
 {% endblock %}

--- a/purchasing/templates/opportunities/emails/signup.html
+++ b/purchasing/templates/opportunities/emails/signup.html
@@ -4,7 +4,6 @@
 <h2>Hello and welcome to Beacon!</h2>
 <p>Thanks for subscribing for updates about opportunities to do business with the City of Pittsburgh! We hope you'll find an opportunity that's right for your business.</p>
 
-
 {% if categories|length > 20 %}
 <p>You've signed up to receive notifications about {{ categories|length }} categories. You can view all of them <a href="{{ url_for('opportunities.manage', _external=True) }}">here.</a></p>
 {% else %}

--- a/purchasing/templates/opportunities/emails/signup.html
+++ b/purchasing/templates/opportunities/emails/signup.html
@@ -5,7 +5,6 @@
 <p>Thanks for subscribing for updates about opportunities to do business with the City of Pittsburgh! We hope you'll find an opportunity that's right for your business.</p>
 {% endblock %}
 
-{% block panel %}
 {% if categories|length > 20 %}
 <p>You've signed up to receive notifications about {{ categories|length }} categories. You can view all of them <a href="{{ url_for('opportunities.manage', _external=True) }}">here.</a></p>
 {% else %}
@@ -15,12 +14,10 @@
   <li>{{ category.subcategory }}</li>
   {% endfor %}
 </ul>
-{% endif %}
-{% endblock %}
 
-{% block content %}
 <p>Every 2 weeks, we’ll send a short summary of all opportunities that have been posted, so you don’t miss out on potential business. 
 </p>
+<p>Have a question? Click on the link at the end of this message to send us an email, and we'll get back to you as soon as we can.</p>
 <p>Thanks,<br>
     - The Beacon team
 </p>

--- a/purchasing/templates/opportunities/emails/signup.html
+++ b/purchasing/templates/opportunities/emails/signup.html
@@ -15,15 +15,9 @@
 </ul>
 {% endif %}
 
-<p>Every 2 weeks, we’ll send a short summary of all opportunities that have been posted, so you don’t miss out on potential business. 
+<p>Every two weeks, we’ll send a short summary of all opportunities that have been posted, so you don’t miss out on potential business. 
 </p>
 <p>Have a question? Click on the link at the end of this message to send us an email, and we'll get back to you as soon as we can.</p>
-<p>Thanks,<br>
-    - The Beacon team
-</p>
-
-<p>Every 2 weeks, we’ll send a short summary of all opportunities that have been posted, so you don’t miss out on potential business. 
-</p>
 <p>Thanks,<br>
     - The Beacon team
 </p>

--- a/purchasing/templates/opportunities/emails/signup.txt
+++ b/purchasing/templates/opportunities/emails/signup.txt
@@ -1,13 +1,19 @@
-Thank you for subscribing for updates about Pittsburgh Opportunities!
+Hello and welcome to Beacon! Thanks for subscribing for updates about opportunities to do business with the City of Pittsburgh! We hope you'll find an opportunity that's right for your business.
 
 {% if categories|length > 20 %}
-You have signed up to receive notifications about {{ categories|length }} categories!
+You've signed up to receive notifications about {{ categories|length }} categories!
 {% else %}
-You have signed up to receive notifications about the following categories:
+You've signed up to receive notifications about the following categories:
 
 {% for category in categories %}
   {{ category.subcategory }}
 {% endfor %}
 {% endif %}
 
-Manage your notification settings: {{ url_for('opportunities.manage', _external=True) }}
+Every 2 weeks, we’ll send a short summary of all opportunities that have been posted, so you don’t miss out on potential business. 
+
+Thanks,
+The Beacon team
+
+Manage your subscription: {{ url_for('opportunities.manage', _external=True) }}
+Questions? Email us at pittsburgh@codeforamerica.org

--- a/purchasing/templates/opportunities/front/detail.html
+++ b/purchasing/templates/opportunities/front/detail.html
@@ -15,12 +15,12 @@
         {% if opportunity.categories|length > 0 %}
 
         <div class="status status-complete">
-          {% if opportunity.is_advertised() %}
+          {% if opportunity.is_pending %}
           <p class="status-date"><strong>Opening soon!</strong> Accepting proposals starting {{ opportunity.estimate_open() }}</p>
-          {% elif opportunity.is_open() %}
+          {% elif opportunity.is_open %}
           <h3>Open: accepting proposals</h3>
           <p>Responses due by {{ opportunity.estimate_deadline() }}</p>
-          {% elif opportunity.is_expired() %}
+          {% elif opportunity.is_closed %}
           <h3>Closed</h3>
           <p>We are no longer accepting responses.</p>
           {% endif %}
@@ -59,8 +59,8 @@
           <div class="detail-description">
             <h3><strong>What is it?</strong></h3>
             <p>{{ opportunity.description }}</p>
-            {% if opportunity.planned_open.date() > today %}
-            <p><strong>We estimate that this opportunity will start accepting responses on{{ opportunity.estimate_open() }}.</strong></p>
+            {% if opportunity.is_upcoming %}
+            <p><strong>We estimate that this opportunity will start accepting responses on {{ opportunity.estimate_open() }}.</strong></p>
             {% endif %}
           </div>
         </div>

--- a/purchasing_test/unit/factories.py
+++ b/purchasing_test/unit/factories.py
@@ -12,7 +12,7 @@ from purchasing.data.models import (
     Company
 )
 from purchasing.opportunities.models import (
-    Opportunity, RequiredBidDocument, OpportunityDocument
+    Opportunity, RequiredBidDocument, OpportunityDocument, Category
 )
 
 class BaseFactory(SQLAlchemyModelFactory):
@@ -93,3 +93,9 @@ class RequiredBidDocumentFactory(BaseFactory):
 class OpportunityDocumentFactory(BaseFactory):
     class Meta:
         model = OpportunityDocument
+
+class CategoryFactory(BaseFactory):
+    id = factory.Sequence(lambda n: n)
+
+    class Meta:
+        model = Category

--- a/purchasing_test/unit/factories.py
+++ b/purchasing_test/unit/factories.py
@@ -12,7 +12,8 @@ from purchasing.data.models import (
     Company
 )
 from purchasing.opportunities.models import (
-    Opportunity, RequiredBidDocument, OpportunityDocument, Category
+    Opportunity, RequiredBidDocument, OpportunityDocument, Category,
+    Vendor
 )
 
 class BaseFactory(SQLAlchemyModelFactory):
@@ -80,11 +81,23 @@ class ContractPropertyFactory(BaseFactory):
     class Meta:
         model = ContractProperty
 
+class CategoryFactory(BaseFactory):
+    id = factory.Sequence(lambda n: n)
+
+    class Meta:
+        model = Category
+
 class OpportunityFactory(BaseFactory):
     id = factory.Sequence(lambda n: n)
 
     class Meta:
         model = Opportunity
+
+class VendorFactory(BaseFactory):
+    id = factory.Sequence(lambda n: n)
+
+    class Meta:
+        model = Vendor
 
 class RequiredBidDocumentFactory(BaseFactory):
     class Meta:
@@ -93,9 +106,3 @@ class RequiredBidDocumentFactory(BaseFactory):
 class OpportunityDocumentFactory(BaseFactory):
     class Meta:
         model = OpportunityDocument
-
-class CategoryFactory(BaseFactory):
-    id = factory.Sequence(lambda n: n)
-
-    class Meta:
-        model = Category

--- a/purchasing_test/unit/opportunities/test_opportunities.py
+++ b/purchasing_test/unit/opportunities/test_opportunities.py
@@ -6,10 +6,11 @@ from unittest import TestCase
 from flask import current_app
 
 from purchasing.extensions import mail
-from purchasing_test.unit.test_base import BaseTestCase
-from purchasing_test.unit.util import insert_a_role, insert_a_user
 from purchasing.data.importer.nigp import main as import_nigp
 from purchasing.opportunities.models import Vendor
+
+from purchasing_test.unit.test_base import BaseTestCase
+from purchasing_test.unit.util import insert_a_role, insert_a_user
 from purchasing_test.unit.factories import OpportunityFactory
 
 class TestOpportunityModel(TestCase):


### PR DESCRIPTION
#### What Changed
- Changed email formatting - removed gray box and changed default header message
- Changed copy for signup.html and signup.txt emails
- Created oppselected.html and oppselected.txt for emails confirming a business has signed up for selected opportunities
- Created newopp.html and newopp.txt for emails notifying businesses that an opportunity under the categories they signed up for has been posted
- Changed display of estimated_open and estimated_deadline dates from YYYY-MM-DD to Month Day, Year.
- Created plumbing with @bsmithgall to actually send those emails
- Fixed #187 and #188
#### What's Needed
- N/A
#### Screenshots
##### Browse opportunities

Re-styled table that only shows published opportunities. City staff see the dismissable alert reminding them to visit the Pending page for not-yet-published opportunities (both approved for publishing and not yet approved).

![screen shot 2015-08-10 at 2 45 43 pm](https://cloud.githubusercontent.com/assets/1178390/9185262/2c673664-3f6f-11e5-879f-0829692daa81.png)
##### Add new opportunity

OMB staff with publish approval authority see the following option when publishing an opportunity:

![screen shot 2015-08-10 at 2 48 56 pm](https://cloud.githubusercontent.com/assets/1178390/9185272/402c43ec-3f6f-11e5-966f-ca666a62211b.png)
##### Pending opportunities

Style tweaks (date display) and changed Publish button to reflect scheduled publishing date.

![screen shot 2015-08-10 at 3 11 30 pm](https://cloud.githubusercontent.com/assets/1178390/9185645/77427e02-3f72-11e5-8226-1f976fb88c6e.png)
##### Emails

Email after selecting 1 opp to follow:

![screen shot 2015-08-05 at 4 52 00 pm](https://cloud.githubusercontent.com/assets/1178390/9100757/32e63402-3b93-11e5-9fcc-fc54f3c463f6.png)

After filling out the subscribe form (links in footer cut off in screenshot): 

![screen shot 2015-08-05 at 4 58 37 pm](https://cloud.githubusercontent.com/assets/1178390/9100766/4432a254-3b93-11e5-8564-33d22c391d76.png)

New opportunity notice:

![screen shot 2015-08-06 at 4 53 40 pm](https://cloud.githubusercontent.com/assets/1178390/9125987/bf5e7020-3c5b-11e5-96ca-0565b765945f.png)
