### PR TITLE
Added title and meta-description into head section of public-facing Beacon pages

### DIFF
--- a/purchasing/templates/opportunities/browse.html
+++ b/purchasing/templates/opportunities/browse.html
@@ -1,5 +1,9 @@
 {% extends "opportunities/layout.html" %}
 
+{% block page_title %}
+   {{ super() }} - Current and upcoming City of Pittsburgh opportunities
+{% endblock %}
+
 {% block content %}
 <div class="container">
   <div class="row">

--- a/purchasing/templates/opportunities/front/detail.html
+++ b/purchasing/templates/opportunities/front/detail.html
@@ -1,5 +1,9 @@
 {% extends "opportunities/layout.html" %}
 
+{% block page_title %}
+   {{ super() }} - Details about {{ opportunity.title }}
+{% endblock %}
+
 {% block content %}
 
 <div class="container-fluid detail-title">

--- a/purchasing/templates/opportunities/front/signup.html
+++ b/purchasing/templates/opportunities/front/signup.html
@@ -1,6 +1,10 @@
 {% extends "opportunities/layout.html" %}
 {% import "macros/with_errors.html" as macros %}
 
+{% block page_title %}
+   {{ super() }} - Subscribe to City of Pittsburgh opportunities
+{% endblock %}
+
 {% block content %}
 
 <div class="container">

--- a/purchasing/templates/opportunities/front/splash.html
+++ b/purchasing/templates/opportunities/front/splash.html
@@ -1,5 +1,9 @@
 {% extends "opportunities/layout.html" %}
 
+{% block page_title %}
+   {{ super() }} - find and subscribe to City of Pittsburgh opportunities
+{% endblock %}
+
 {% block content %}
 <div class="container-fluid">
 

--- a/purchasing/templates/opportunities/layout.html
+++ b/purchasing/templates/opportunities/layout.html
@@ -1,5 +1,13 @@
 {% extends 'layout.html' %}
 
+{% block page_title %}
+   Beacon
+{% endblock %}
+
+{% block meta_description %}
+Information about opportunities to do business with the City of Pittsburgh, delievered to your email inbox. Beacon is a free City of Pittsburgh service for finding current and upcoming contract opportunities, understanding how to apply for them, and staying in the loop with email notifications when new opportunities are posted.
+{% endblock %}
+
 {% block assets %}
   {% assets "opportunities_less" %}
     <link rel="stylesheet" href="{{ ASSET_URL }}">


### PR DESCRIPTION
#### What Changed
- Public facing Beacon pages (splash, browse, subscribe, and individual opportunity pages) now have titles and meta-descriptions
- Addresses #157 
#### What's Needed
- N/a
#### Screenshots

Splash page title + meta description:

![screen shot 2015-08-11 at 1 15 34 pm](https://cloud.githubusercontent.com/assets/1178390/9209407/33e1daa4-402b-11e5-95a1-8c9c7498e575.png)

Browse page title (differs slightly) + same meta description:

![screen shot 2015-08-11 at 1 15 59 pm](https://cloud.githubusercontent.com/assets/1178390/9209411/39fd9784-402b-11e5-94aa-20f065668eca.png)
