### PR TITLE
Add approved opportunities to pending page

### DIFF
--- a/purchasing/opportunities/admin/views.py
+++ b/purchasing/opportunities/admin/views.py
@@ -236,13 +236,18 @@ def publish(opportunity_id):
 def pending():
     '''View which contracts are currently pending approval
     '''
-    opportunities = Opportunity.query.filter(
+    pending = Opportunity.query.filter(
         Opportunity.is_public == False
     ).all()
 
+    approved = Opportunity.query.filter(
+        Opportunity.planned_advertise > datetime.date.today(),
+        Opportunity.is_public == True
+    ).all()
+
     return render_template(
-        'opportunities/admin/pending.html', opportunities=opportunities,
-        current_user=current_user
+        'opportunities/admin/pending.html', pending=pending,
+        approved=approved, current_user=current_user
     )
 
 def build_downloadable_groups(val, iterable):

--- a/purchasing/opportunities/admin/views.py
+++ b/purchasing/opportunities/admin/views.py
@@ -224,13 +224,18 @@ def publish(opportunity_id):
 def pending():
     '''View which contracts are currently pending approval
     '''
-    opportunities = Opportunity.query.filter(
+    pending = Opportunity.query.filter(
         Opportunity.is_public == False
     ).all()
 
+    approved = Opportunity.query.filter(
+        Opportunity.planned_advertise > datetime.date.today(),
+        Opportunity.is_public == True
+    ).all()
+
     return render_template(
-        'opportunities/admin/pending.html', opportunities=opportunities,
-        current_user=current_user
+        'opportunities/admin/pending.html', pending=pending,
+        approved=approved, current_user=current_user
     )
 
 def build_downloadable_groups(val, iterable):

--- a/purchasing/opportunities/front/views.py
+++ b/purchasing/opportunities/front/views.py
@@ -262,7 +262,7 @@ def detail(opportunity_id):
     '''View one opportunity in detail
     '''
     opportunity = Opportunity.query.get(opportunity_id)
-    if opportunity and (opportunity.is_public or not current_user.is_anonymous()):
+    if opportunity and opportunity.can_view(current_user):
         signup_form = init_form(OpportunitySignupForm)
         if signup_form.validate_on_submit():
             signup_success = signup_for_opp(signup_form, current_user, opportunity)

--- a/purchasing/opportunities/models.py
+++ b/purchasing/opportunities/models.py
@@ -114,7 +114,7 @@ class Opportunity(Model):
     def can_view(self, user):
         '''Check if a user can see opportunity detail
         '''
-        return False if user.is_anonymous() else True
+        return False if user.is_anonymous() and not self.is_advertised else True
 
     def can_edit(self, user):
         '''Check if a user can edit the contract

--- a/purchasing/opportunities/models.py
+++ b/purchasing/opportunities/models.py
@@ -111,6 +111,11 @@ class Opportunity(Model):
     def is_closed(self):
         return self.coerce_to_date(self.planned_deadline) <= datetime.date.today() and self.is_public
 
+    def can_view(self, user):
+        '''Check if a user can see opportunity detail
+        '''
+        return False if user.is_anonymous() else True
+
     def can_edit(self, user):
         '''Check if a user can edit the contract
         '''

--- a/purchasing/static/less/opportunities/_styles.less
+++ b/purchasing/static/less/opportunities/_styles.less
@@ -126,6 +126,11 @@ h4 {
 
 }
 
+.beacon-detail {
+  margin-left: -15px;
+  margin-right: -15px
+}
+
 .faq-question {
   h2, p {
     padding-top: 7px;

--- a/purchasing/templates/opportunities/admin/pending.html
+++ b/purchasing/templates/opportunities/admin/pending.html
@@ -83,7 +83,7 @@
               </tr>
             </thead>
             <tbody>
-              {% for opportunity in approved %}
+              {% for opportunity in approved|sort(attribute='planned_advertise') %}
               <tr>
                 <td class="col-md-5"><a href="{{ url_for('opportunities.detail', opportunity_id=opportunity.id) }}">{{ opportunity.title }}</a></td>
                 <td class="col-md-3">{{ opportunity.department }}</td>

--- a/purchasing/templates/opportunities/admin/pending.html
+++ b/purchasing/templates/opportunities/admin/pending.html
@@ -11,7 +11,7 @@
       <h3><strong>Opportunities awaiting OMB approval</strong></h3>
       <div class="spacer-20"></div>
 
-      {% for opportunity in opportunities %}
+      {% for opportunity in pending %}
       <div class="pending-opportunity">
         <div class="row">
           <div class="col-xs-12">
@@ -28,7 +28,7 @@
                 </a>
                 {% endif %}
                 {% if not current_user.is_anonymous() and current_user.is_conductor() %}
-                  <a href="{{ url_for('opportunities_admin.publish', opportunity_id=opportunity.id) }}" class="btn btn-primary">Publish on {{ opportunity.planned_open.strftime('%m/%d/%y') }}</a>
+                  <a href="{{ url_for('opportunities_admin.publish', opportunity_id=opportunity.id) }}" class="btn btn-primary">Publish on {{ opportunity.planned_advertise.strftime('%m/%d/%y') }}</a>
                 {% endif %}
                 </div>
               </div>
@@ -41,11 +41,11 @@
             <div class="row">
               <div class="col-xs-4">
                 <h4>Planned Advertise Date</h4>
-                <p>{{ opportunity.planned_open.strftime('%m/%d/%y') }}</p>
+                <p>{{ opportunity.planned_advertise.strftime('%m/%d/%y') }}</p>
               </div>
               <div class="col-xs-4">
                 <h4>Planned Open Date</h4>
-                <p>{{ opportunity.planned_deadline.strftime('%m/%d/%y') }}</p>
+                <p>{{ opportunity.planned_open.strftime('%m/%d/%y') }}</p>
               </div>
               <div class="col-xs-4">
                 <h4>Planned Deadline</h4>
@@ -59,10 +59,47 @@
       </div><!-- pending opportunity card -->
       {% endfor %}
 
-      {% if opportunities|length == 0 %}
+      {% if pending|length == 0 %}
       <p class="lead">
         There are no currently pending opportunities. You can <a href="{{ url_for('opportunities_admin.new') }}">create a new one</a> and it will appear here!
       </p>
+      {% endif %}
+
+      {% if approved|length > 0 %}
+      <h3><strong>Opportunities approved and scheduled to publish</strong></h3>
+      <div class="spacer-20"></div>
+
+      <div class="pending-opportunity">
+        <div class="table-responsive">
+          <table class="table table-striped">
+            <thead>
+              <tr>
+                <th>Opportunity</th>
+                <th>Department</th>
+                <th>Advertised</th>
+                {% if not current_user.is_anonymous() %}
+                <th>Edit </th>
+                {% endif %}
+              </tr>
+            </thead>
+            <tbody>
+              {% for opportunity in approved %}
+              <tr>
+                <td class="col-md-5"><a href="{{ url_for('opportunities.detail', opportunity_id=opportunity.id) }}">{{ opportunity.title }}</a></td>
+                <td class="col-md-3">{{ opportunity.department }}</td>
+                <td class="col-md-2">{{ opportunity.planned_advertise.strftime('%m/%d/%y') }}</td>
+                {% if opportunity.can_edit(current_user) %}
+                <td class="col-md-2"><a href="{{ url_for('opportunities_admin.edit', opportunity_id=opportunity.id) }}">Edit</a></td>
+                {% elif not current_user.is_anonymous() %}
+                <td><i class="fa fa-minus"></i></td>
+                {% endif %}
+              </tr>
+            {% endfor %}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
       {% endif %}
 
     </div>

--- a/purchasing/templates/opportunities/admin/pending.html
+++ b/purchasing/templates/opportunities/admin/pending.html
@@ -76,7 +76,7 @@
               <tr>
                 <th>Opportunity</th>
                 <th>Department</th>
-                <th>Advertised</th>
+                <th>Public on</th>
                 {% if not current_user.is_anonymous() %}
                 <th>Edit </th>
                 {% endif %}

--- a/purchasing/templates/opportunities/admin/pending.html
+++ b/purchasing/templates/opportunities/admin/pending.html
@@ -69,35 +69,33 @@
       <h3><strong>Opportunities approved and scheduled to publish</strong></h3>
       <div class="spacer-20"></div>
 
-      <div class="pending-opportunity">
-        <div class="table-responsive">
-          <table class="table table-striped">
-            <thead>
-              <tr>
-                <th>Opportunity</th>
-                <th>Department</th>
-                <th>Public on</th>
-                {% if not current_user.is_anonymous() %}
-                <th>Edit </th>
-                {% endif %}
-              </tr>
-            </thead>
-            <tbody>
-              {% for opportunity in approved|sort(attribute='planned_advertise') %}
-              <tr>
-                <td class="col-md-5"><a href="{{ url_for('opportunities.detail', opportunity_id=opportunity.id) }}">{{ opportunity.title }}</a></td>
-                <td class="col-md-3">{{ opportunity.department }}</td>
-                <td class="col-md-2">{{ opportunity.planned_advertise.strftime('%m/%d/%y') }}</td>
-                {% if opportunity.can_edit(current_user) %}
-                <td class="col-md-2"><a href="{{ url_for('opportunities_admin.edit', opportunity_id=opportunity.id) }}">Edit</a></td>
-                {% elif not current_user.is_anonymous() %}
-                <td><i class="fa fa-minus"></i></td>
-                {% endif %}
-              </tr>
-            {% endfor %}
-            </tbody>
-          </table>
-        </div>
+      <div class="table-responsive">
+        <table class="table table-striped table-beacon">
+          <thead>
+            <tr>
+              <th>Opportunity</th>
+              <th>Department</th>
+              <th>Public on</th>
+              {% if not current_user.is_anonymous() %}
+              <th>Edit </th>
+              {% endif %}
+            </tr>
+          </thead>
+          <tbody>
+            {% for opportunity in approved|sort(attribute='planned_advertise') %}
+            <tr>
+              <td class="col-md-5"><a href="{{ url_for('opportunities.detail', opportunity_id=opportunity.id) }}">{{ opportunity.title }}</a></td>
+              <td class="col-md-3">{{ opportunity.department }}</td>
+              <td class="col-md-2">{{ opportunity.planned_advertise.strftime('%m/%d/%y') }}</td>
+              {% if opportunity.can_edit(current_user) %}
+              <td class="col-md-2"><a href="{{ url_for('opportunities_admin.edit', opportunity_id=opportunity.id) }}">Edit</a></td>
+              {% elif not current_user.is_anonymous() %}
+              <td><i class="fa fa-minus"></i></td>
+              {% endif %}
+            </tr>
+          {% endfor %}
+          </tbody>
+        </table>
       </div>
 
       {% endif %}

--- a/purchasing/templates/opportunities/front/detail.html
+++ b/purchasing/templates/opportunities/front/detail.html
@@ -19,7 +19,7 @@
         {% if opportunity.categories|length > 0 %}
 
         <div class="status status-complete">
-          {% if opportunity.is_pending %}
+          {% if opportunity.is_upcoming %}
           <p class="status-date"><strong>Opening soon!</strong> Accepting proposals starting {{ opportunity.estimate_open() }}</p>
           {% elif opportunity.is_open %}
           <h3>Open: accepting proposals</h3>

--- a/purchasing/templates/opportunities/front/detail.html
+++ b/purchasing/templates/opportunities/front/detail.html
@@ -60,7 +60,7 @@
       <div class="col-sm-8">
 
         {% if not opportunity.is_advertised %}
-           <div class="alert alert-warning" role="alert">
+           <div class="alert alert-warning beacon-detail" role="alert">
               This opportunity will not be viewable by the general public until advertised on {{ opportunity.planned_advertise.strftime('%B %d, %Y') }}
           </div>
         {% endif %}

--- a/purchasing/templates/opportunities/front/detail.html
+++ b/purchasing/templates/opportunities/front/detail.html
@@ -59,6 +59,12 @@
       {% include 'includes/flashes.html' %}
       <div class="col-sm-8">
 
+        {% if not opportunity.is_advertised %}
+           <div class="alert alert-warning" role="alert">
+              This opportunity will not be viewable by the general public until advertised on {{ opportunity.planned_advertise.strftime('%B %d, %Y') }}
+          </div>
+        {% endif %}
+
         <div class="row">
           <div class="detail-description">
             <h3><strong>What is it?</strong></h3>

--- a/purchasing_test/unit/opportunities/test_opportunity_admin.py
+++ b/purchasing_test/unit/opportunities/test_opportunity_admin.py
@@ -434,6 +434,10 @@ class TestOpportunitiesPublic(TestOpportunitiesAdminBase):
         self.assertEquals(admin_publish.status_code, 302)
         self.assertTrue(Opportunity.query.get(self.opportunity1.id).is_public)
         self.assertFalse(Opportunity.query.get(self.opportunity1.id).is_advertised)
+        self.assert200(self.client.get('/beacon/opportunities/{}'.format(self.opportunity1.id)))
+
+        self.logout_user()
+        self.assert404(self.client.get('/beacon/opportunities/{}'.format(self.opportunity1.id)))
 
     def test_pending_notification_email_gated(self):
         '''Test we don't send an email when the opportunity is not advertised

--- a/purchasing_test/unit/opportunities/test_opportunity_admin.py
+++ b/purchasing_test/unit/opportunities/test_opportunity_admin.py
@@ -267,8 +267,8 @@ class TestOpportunitiesAdmin(TestOpportunitiesAdminBase):
     def test_contract_detail(self):
         '''Test individual contract opportunity pages
         '''
-        self.assert200(self.client.get('/beacon/opportunities/{}'.format(self.opportunity1.id)))
-        self.assert200(self.client.get('/beacon/opportunities/{}'.format(self.opportunity2.id)))
+        self.assert200(self.client.get('/beacon/opportunities/{}'.format(self.opportunity3.id)))
+        self.assert200(self.client.get('/beacon/opportunities/{}'.format(self.opportunity4.id)))
         self.assert404(self.client.get('/beacon/opportunities/999'))
 
     def test_signup_for_multiple_opportunities(self):
@@ -278,9 +278,9 @@ class TestOpportunitiesAdmin(TestOpportunitiesAdminBase):
         # duplicates should get filtered out
         post = self.client.post('/beacon/opportunities', data=MultiDict([
             ('email', 'foo@foo.com'), ('business_name', 'foo'),
-            ('opportunity', str(self.opportunity1.id)),
-            ('opportunity', str(self.opportunity2.id)),
-            ('opportunity', str(self.opportunity1.id))
+            ('opportunity', str(self.opportunity3.id)),
+            ('opportunity', str(self.opportunity4.id)),
+            ('opportunity', str(self.opportunity3.id))
         ]))
 
         self.assertEquals(Vendor.query.count(), 1)
@@ -288,7 +288,7 @@ class TestOpportunitiesAdmin(TestOpportunitiesAdminBase):
         # should subscribe that vendor to the opportunity
         self.assertEquals(len(Vendor.query.get(1).opportunities), 2)
         for i in Vendor.query.get(1).opportunities:
-            self.assertTrue(i.id in [self.opportunity1.id, self.opportunity2.id])
+            self.assertTrue(i.id in [self.opportunity3.id, self.opportunity4.id])
 
         # should redirect and flash properly
         self.assertEquals(post.status_code, 302)
@@ -299,7 +299,7 @@ class TestOpportunitiesAdmin(TestOpportunitiesAdminBase):
         '''
         with mail.record_messages() as outbox:
             self.assertEquals(Vendor.query.count(), 0)
-            post = self.client.post('/beacon/opportunities/{}'.format(self.opportunity1.id), data={
+            post = self.client.post('/beacon/opportunities/{}'.format(self.opportunity3.id), data={
                 'email': 'foo@foo.com', 'business_name': 'foo'
             })
             # should create a new vendor
@@ -307,7 +307,7 @@ class TestOpportunitiesAdmin(TestOpportunitiesAdminBase):
 
             # should subscribe that vendor to the opportunity
             self.assertEquals(len(Vendor.query.first().opportunities), 1)
-            self.assertTrue(self.opportunity1.id in [i.id for i in Vendor.query.first().opportunities])
+            self.assertTrue(self.opportunity3.id in [i.id for i in Vendor.query.first().opportunities])
 
             # should redirect and flash properly
             self.assertEquals(post.status_code, 302)
@@ -400,7 +400,7 @@ class TestOpportunitiesPublic(TestOpportunitiesAdminBase):
         self.login_user(self.staff)
         staff_pending = self.client.get('/beacon/admin/opportunities/pending')
         self.assert200(staff_pending)
-        self.assertEquals(len(self.get_context_variable('opportunities')), 1)
+        self.assertEquals(len(self.get_context_variable('pending')), 1)
         self.assertTrue('Publish' not in staff_pending.data)
         # make sure staff can't publish somehow
         staff_publish = self.client.get('/beacon/admin/opportunities/{}/publish'.format(self.opportunity3.id))
@@ -414,7 +414,7 @@ class TestOpportunitiesPublic(TestOpportunitiesAdminBase):
         self.login_user(self.admin)
         admin_pending = self.client.get('/beacon/admin/opportunities/pending')
         self.assert200(admin_pending)
-        self.assertEquals(len(self.get_context_variable('opportunities')), 1)
+        self.assertEquals(len(self.get_context_variable('pending')), 1)
         self.assertTrue('Publish' in admin_pending.data)
         admin_publish = self.client.get('/beacon/admin/opportunities/{}/publish'.format(
             self.opportunity3.id

--- a/purchasing_test/unit/opportunities/test_opportunity_admin.py
+++ b/purchasing_test/unit/opportunities/test_opportunity_admin.py
@@ -423,6 +423,18 @@ class TestOpportunitiesPublic(TestOpportunitiesAdminBase):
         self.assertEquals(admin_publish.status_code, 302)
         self.assertTrue(Opportunity.query.get(self.opportunity3.id).is_public)
 
+    def test_approved_opportunity(self):
+        '''Test approved opportunities work as expected for city staff
+        '''
+        self.login_user(self.admin)
+        admin_publish = self.client.get('/beacon/admin/opportunities/{}/publish'.format(
+            self.opportunity1.id
+        ))
+        self.assert_flashes('Opportunity successfully published!', 'alert-success')
+        self.assertEquals(admin_publish.status_code, 302)
+        self.assertTrue(Opportunity.query.get(self.opportunity1.id).is_public)
+        self.assertFalse(Opportunity.query.get(self.opportunity1.id).is_advertised)
+
     def test_pending_notification_email_gated(self):
         '''Test we don't send an email when the opportunity is not advertised
         '''


### PR DESCRIPTION
### What changed
- added view of opportunities approved by omb but not advertised yet
### What's needed
- [x] gate for approved, but not-yet-public contracts
- [x] sort by advertise date
- [x] update tests
- [x] write new test
### Issues
- #195 
### Screencap

<img width="1212" alt="screen shot 2015-08-11 at 2 58 37 pm" src="https://cloud.githubusercontent.com/assets/3640800/9211836/7b746fc2-4039-11e5-8179-4603cfb1738f.png">
