### PR TITLE
Updated opportunities/_styles.less 

### DIFF
--- a/purchasing/static/less/opportunities/_styles.less
+++ b/purchasing/static/less/opportunities/_styles.less
@@ -1,3 +1,12 @@
+
+a {
+  font-weight: 600;
+}
+
+.navbar a {
+  font-weight: 400;
+}
+
 h1 {
   @media @mobile {
     font-size: 32px
@@ -156,4 +165,14 @@ h4 {
 
 .submit-dropdown {
   left: 15px;
+}
+
+.table-beacon th {
+  font-size: 13px;
+  color: #9d9d9d;
+  font-weight: 400;
+}
+
+.table-beacon a {
+  font-weight: 600;
 }

--- a/purchasing/templates/opportunities/browse.html
+++ b/purchasing/templates/opportunities/browse.html
@@ -28,7 +28,7 @@
 
         {% if _open|length > 0 %}
         <div class="table-responsive">
-          <table class="table table-striped">
+          <table class="table table-striped table-beacon">
             <thead>
               <tr>
                 <th>Select</th>
@@ -68,7 +68,7 @@
 
         {% if upcoming|length > 0 %}
         <div class="table-responsive">
-          <table class="table table-striped">
+          <table class="table table-striped table-beacon">
             <thead>
               <tr>
                 <th>Select</th>

--- a/purchasing/templates/wexplorer/search.html
+++ b/purchasing/templates/wexplorer/search.html
@@ -46,7 +46,7 @@
       <table class="table table-striped" id="js-sort-results">
         <thead>
           <tr>
-            <th class="js-sortable-th">Contract Discription</th>
+            <th class="js-sortable-th">Contract Description</th>
             <th class="js-sortable-th">Company</th>
             <th class="js-sortable-th">Expiration Date</th>
             <th class="js-sortable-th">Controller Number</th>


### PR DESCRIPTION
#### What Changed
- Fixed #201 
- Table headings, table links, and body link style changes
#### What's Needed

N/A
#### Screenshots

Table links are bolded, and table heading text is smaller and lighter

![screen shot 2015-08-12 at 2 30 07 pm](https://cloud.githubusercontent.com/assets/1178390/9237239/b5dd1d10-40fe-11e5-8f17-8c01b3120663.png)

Links on Beacon are now bolded everywhere except the navbar:

![screen shot 2015-08-12 at 2 30 20 pm](https://cloud.githubusercontent.com/assets/1178390/9237240/b5de9fc8-40fe-11e5-9e97-b1cf8883aaca.png)
