### PR TITLE
Subscribe button viewable by ~* everybody *~

### DIFF
--- a/purchasing/decorators.py
+++ b/purchasing/decorators.py
@@ -16,7 +16,11 @@ def requires_roles(*roles):
     def check_roles(view_function):
         @wraps(view_function)
         def decorated_function(*args, **kwargs):
-            if current_user.is_anonymous() or current_user.role.name not in roles:
+
+            if current_user.is_anonymous():
+                flash('This feature is for city staff only. If you are staff, log in with your pittsburghpa.gov email using the link to the upper right.', 'alert-warning')
+                return redirect(request.args.get('next') or '/')
+            elif current_user.role.name not in roles:
                 flash('You do not have sufficent permissions to do that!', 'alert-danger')
                 return redirect(request.args.get('next') or '/')
             return view_function(*args, **kwargs)

--- a/purchasing/templates/wexplorer/contract.html
+++ b/purchasing/templates/wexplorer/contract.html
@@ -10,22 +10,17 @@
 
       <div class="well wexplorer-well">
         <div class="row">
-          {% if current_user.role.name == 'anonymous' %}
-          <div class="col-sm-12"><h3><strong>
-            {{ contract.description|title }}
-          </strong></h3></div>
-          {% else %}
           <div class="col-sm-9"><h3><strong>
               {{ contract.description|title }}
           </strong></h3></div>
           <div class="col-sm-3">
             {% if current_user in contract.followers %}
               <a href="{{ url_for('wexplorer.unsubscribe', contract_id=contract.id, next=path) }}" class="btn btn-danger pull-right btn-header">Stop receiving updates</a>
-            {% elif current_user.role.name != 'anonymous' %}
+            {% else %}
               <a href="{{ url_for('wexplorer.subscribe', contract_id=contract.id, next=path) }}" class="btn btn-primary pull-right btn-header">Subscribe for updates</a>
             {% endif %}
           </div>
-          {% endif %}
+
         </div>
 
         {% if current_user.role.name in ['admin', 'superadmin'] %}
@@ -44,6 +39,7 @@
         <p>
           See something wrong? <a href="{{ url_for('wexplorer.feedback', contract_id=contract.id) }}" target="_blank">Send your feedback.</a>
         </p>
+
 
       <hr>
 

--- a/purchasing/templates/wexplorer/search.html
+++ b/purchasing/templates/wexplorer/search.html
@@ -85,7 +85,7 @@
                 Stop receiving updates
               </a>
             </td>
-            {% elif current_user.role.name %}
+            {% else %}
             <td>
               <a href="{{ url_for('wexplorer.subscribe', contract_id=result.contract_id, next=path) }}" class="btn btn-primary">
                 Subscribe for updates

--- a/purchasing/templates/wexplorer/search.html
+++ b/purchasing/templates/wexplorer/search.html
@@ -50,9 +50,9 @@
             <th class="js-sortable-th">Company</th>
             <th class="js-sortable-th">Expiration Date</th>
             <th class="js-sortable-th">Controller Number</th>
-            {% if current_user.is_anonymous() == False %}
+
             <th>Subscribe to updates</th>
-            {% endif %}
+
           </tr>
         </thead>
         <tbody>
@@ -78,8 +78,8 @@
             </td>
             <td>{{ result.expiration_date }}</td>
             <td>{{ result.financial_id }}</td>
-            {% if current_user.is_anonymous() %}
-            {% elif result.contract_id in user_follows %}
+
+            {% if result.contract_id in user_follows %}
             <td>
               <a href="{{ url_for('wexplorer.unsubscribe', contract_id=result.contract_id, next=path) }}" class="btn btn-danger">
                 Stop receiving updates

--- a/purchasing_test/unit/conductor/test_conductor_upload.py
+++ b/purchasing_test/unit/conductor/test_conductor_upload.py
@@ -57,7 +57,7 @@ class TestCostarsUpload(BaseTestCase):
         '''
         # test that you can't access upload page unless you are signed in with proper role
         self.assertEqual(self.client.get('/conductor/upload/costars').status_code, 302)
-        self.assert_flashes('You do not have sufficent permissions to do that!', 'alert-danger')
+        self.assert_flashes('This feature is for city staff only. If you are staff, log in with your pittsburghpa.gov email using the link to the upper right.', 'alert-warning')
 
         for user in [self.conductor, self.admin, self.superadmin]:
             self.login_user(user)
@@ -69,7 +69,7 @@ class TestCostarsUpload(BaseTestCase):
         test_file = self.create_file('costars-99.csv', 'text/csv')
         upload_csv = self.client.post('/conductor/upload/costars', data=dict(upload=test_file))
         self.assertEqual(upload_csv.status_code, 302)
-        self.assert_flashes('You do not have sufficent permissions to do that!', 'alert-danger')
+        self.assert_flashes('This feature is for city staff only. If you are staff, log in with your pittsburghpa.gov email using the link to the upper right.', 'alert-warning')
 
         for user in [self.conductor, self.admin, self.superadmin]:
             self.login_user(user)

--- a/purchasing_test/unit/opportunities/test_opportunity_admin.py
+++ b/purchasing_test/unit/opportunities/test_opportunity_admin.py
@@ -162,7 +162,7 @@ class TestOpportunitiesAdmin(TestOpportunitiesAdminBase):
         '''
         self.assertEquals(Opportunity.query.count(), 4)
         self.assertEquals(self.client.get('/beacon/admin/opportunities/new').status_code, 302)
-        self.assert_flashes('You do not have sufficent permissions to do that!', 'alert-danger')
+        self.assert_flashes('This feature is for city staff only. If you are staff, log in with your pittsburghpa.gov email using the link to the upper right.', 'alert-warning')
 
         self.login_user(self.admin)
         self.assert200(self.client.get('/beacon/admin/opportunities/new'))
@@ -216,7 +216,7 @@ class TestOpportunitiesAdmin(TestOpportunitiesAdminBase):
         self.assertEquals(self.client.get('/beacon/admin/opportunities/{}'.format(
             self.opportunity2.id
         )).status_code, 302)
-        self.assert_flashes('You do not have sufficent permissions to do that!', 'alert-danger')
+        self.assert_flashes('This feature is for city staff only. If you are staff, log in with your pittsburghpa.gov email using the link to the upper right.', 'alert-warning')
 
         self.login_user(self.admin)
         self.assert200(self.client.get('/beacon/admin/opportunities/{}'.format(
@@ -252,7 +252,7 @@ class TestOpportunitiesAdmin(TestOpportunitiesAdminBase):
         opp_doc = OpportunityDocument.query.filter(OpportunityDocument.name == 'the_test_document').first()
         self.client.get('/beacon/admin/opportunities/{}/document/{}/remove'.format(opp.id, opp_doc.id))
         self.assertEquals(len(opp.opportunity_documents.all()), 1)
-        self.assert_flashes('You do not have sufficent permissions to do that!', 'alert-danger')
+        self.assert_flashes('This feature is for city staff only. If you are staff, log in with your pittsburghpa.gov email using the link to the upper right.', 'alert-warning')
 
         self.login_user(self.admin)
 
@@ -320,7 +320,7 @@ class TestOpportunitiesAdmin(TestOpportunitiesAdminBase):
         '''
         request = self.client.get('/beacon/admin/signups')
         self.assertEquals(request.status_code, 302)
-        self.assert_flashes('You do not have sufficent permissions to do that!', 'alert-danger')
+        self.assert_flashes('This feature is for city staff only. If you are staff, log in with your pittsburghpa.gov email using the link to the upper right.', 'alert-warning')
 
     def test_signup_download_staff(self):
         '''Test signup downloads work properly
@@ -390,7 +390,7 @@ class TestOpportunitiesPublic(TestOpportunitiesAdminBase):
         self.assertEquals(self.client.get('/beacon/admin/opportunities/pending').status_code, 302)
         random_publish = self.client.get('/beacon/admin/opportunities/{}/publish'.format(self.opportunity3.id))
         self.assertEquals(random_publish.status_code, 302)
-        self.assert_flashes('You do not have sufficent permissions to do that!', 'alert-danger')
+        self.assert_flashes('This feature is for city staff only. If you are staff, log in with your pittsburghpa.gov email using the link to the upper right.', 'alert-warning')
         self.assertFalse(self.opportunity3.is_public)
 
     def test_pending_opportunity_staff(self):

--- a/purchasing_test/unit/wexplorer/test_wexplorer.py
+++ b/purchasing_test/unit/wexplorer/test_wexplorer.py
@@ -78,7 +78,7 @@ class TestWexplorer(BaseTestCase):
         # test that you can't subscribe to a contract unless you are signed in
         request = self.client.get('/scout/contracts/1/subscribe')
         self.assertEquals(request.status_code, 302)
-        self.assert_flashes('You do not have sufficent permissions to do that!', 'alert-danger')
+        self.assert_flashes('This feature is for city staff only. If you are staff, log in with your pittsburghpa.gov email using the link to the upper right.', 'alert-warning')
 
         self.login_user(self.admin_user)
         request = self.client.get('/scout/contracts/1/subscribe')
@@ -101,7 +101,7 @@ class TestWexplorer(BaseTestCase):
         # test that you can't subscribe to a contract unless you are signed in
         request = self.client.get('/scout/contracts/1/unsubscribe')
         self.assertEquals(request.status_code, 302)
-        self.assert_flashes('You do not have sufficent permissions to do that!', 'alert-danger')
+        self.assert_flashes('This feature is for city staff only. If you are staff, log in with your pittsburghpa.gov email using the link to the upper right.', 'alert-warning')
 
         # two followers
         self.login_user(self.admin_user)
@@ -128,7 +128,7 @@ class TestWexplorer(BaseTestCase):
         '''
         request = self.client.get('/scout/contracts/1/star')
         self.assertEquals(request.status_code, 302)
-        self.assert_flashes('You do not have sufficent permissions to do that!', 'alert-danger')
+        self.assert_flashes('This feature is for city staff only. If you are staff, log in with your pittsburghpa.gov email using the link to the upper right.', 'alert-warning')
 
         self.login_user(self.admin_user)
         request = self.client.get('/scout/contracts/1/star')
@@ -151,7 +151,7 @@ class TestWexplorer(BaseTestCase):
         # test that you can't unstar to a contract unless you are signed in
         request = self.client.get('/scout/contracts/1/unstar')
         self.assertEquals(request.status_code, 302)
-        self.assert_flashes('You do not have sufficent permissions to do that!', 'alert-danger')
+        self.assert_flashes('This feature is for city staff only. If you are staff, log in with your pittsburghpa.gov email using the link to the upper right.', 'alert-warning')
 
         # two followers
         self.login_user(self.admin_user)


### PR DESCRIPTION
#### What Changed
- Fixed #217 
- Subscribe button viewable by everyone on Scout. If user isn't logged into pittsburghpa.gov account, clicking on the subscribe button causes an alert to appear, reminding the user to log in.
#### What's Needed

n/a
#### Screenshots

Views for anonymous user:

![screen shot 2015-08-13 at 5 25 34 pm](https://cloud.githubusercontent.com/assets/1178390/9264892/850eebea-41e0-11e5-8fcc-583bd290e1ea.png)

![screen shot 2015-08-13 at 5 25 43 pm](https://cloud.githubusercontent.com/assets/1178390/9264891/850ea392-41e0-11e5-8b8c-24e2316e3705.png)

![screen shot 2015-08-13 at 5 25 58 pm](https://cloud.githubusercontent.com/assets/1178390/9264890/850e75a2-41e0-11e5-8fbe-22ea3d2aad62.png)

Views for city staff logged in:

![screen shot 2015-08-13 at 5 26 36 pm](https://cloud.githubusercontent.com/assets/1178390/9264895/941d0e0a-41e0-11e5-90e9-e2e782e3d995.png)

![screen shot 2015-08-13 at 5 26 17 pm](https://cloud.githubusercontent.com/assets/1178390/9264898/974a6794-41e0-11e5-8a41-4d1273990e69.png)
