### PR TITLE
add spec number to searches in admin

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,7 @@
     "datatables": "~1.10.7",
     "html5shiv": "~3.7.3",
     "respond": "~1.4.2",
-    "select2": "~4.0.0"
+    "select2": "~4.0.0",
+    "moment": "~2.10.6"
   }
 }

--- a/purchasing/admin/views.py
+++ b/purchasing/admin/views.py
@@ -31,8 +31,29 @@ class CompanyAdmin(AuthMixin, sqla.ModelView):
 class ContractBaseAdmin(AuthMixin, sqla.ModelView):
     '''Base model for different representations of contracts
     '''
+    column_auto_select_related = True
     column_labels = dict(financial_id='Controller Number')
-    column_searchable_list = ('description', 'contract_type')
+    column_searchable_list = (ContractBase.description, ContractBase.contract_type, ContractProperty.value)
+
+    column_list = [
+        'contract_type', 'description', 'financial_id', 'expiration_date',
+        'is_archived', 'properties'
+    ]
+
+    column_labels = dict(
+        contract_href='Link to Contract PDF', financial_id='Controller #',
+        properties='Spec #', expiration_date='Expiration', is_archived='Archived'
+    )
+
+    def get_query(self):
+        return super(ContractBaseAdmin, self).get_query().outerjoin(ContractProperty).filter(
+            db.func.lower(ContractProperty.key) == 'spec number'
+        )
+
+    def get_count_query(self):
+        return super(ContractBaseAdmin, self).get_count_query().outerjoin(ContractProperty).filter(
+            db.func.lower(ContractProperty.key) == 'spec number'
+        )
 
 class ScoutContractAdmin(ContractBaseAdmin):
     inline_models = (ContractProperty, LineItem,)
@@ -43,12 +64,7 @@ class ScoutContractAdmin(ContractBaseAdmin):
         'companies', 'followers', 'starred', 'is_archived'
     ]
 
-    column_labels = dict(contract_href='Link to Contract PDF')
-
-    column_list = [
-        'contract_type', 'description', 'financial_id', 'expiration_date',
-        'is_archived'
-    ]
+    column_labels = dict(contract_href='Link to Contract PDF', financial_id='Controller #')
 
 class ConductorContractAdmin(ContractBaseAdmin):
     inline_models = (ContractProperty,)

--- a/purchasing/admin/views.py
+++ b/purchasing/admin/views.py
@@ -31,8 +31,9 @@ class CompanyAdmin(AuthMixin, sqla.ModelView):
 class ContractBaseAdmin(AuthMixin, sqla.ModelView):
     '''Base model for different representations of contracts
     '''
-    column_auto_select_related = True
-    column_labels = dict(financial_id='Controller Number')
+    edit_template = 'admin/purchasing_edit.html'
+    create_template = 'admin/purchasing_create.html'
+
     column_searchable_list = (ContractBase.description, ContractBase.contract_type, ContractProperty.value)
 
     column_list = [
@@ -42,18 +43,8 @@ class ContractBaseAdmin(AuthMixin, sqla.ModelView):
 
     column_labels = dict(
         contract_href='Link to Contract PDF', financial_id='Controller #',
-        properties='Spec #', expiration_date='Expiration', is_archived='Archived'
+        properties='Contract Properties', expiration_date='Expiration', is_archived='Archived'
     )
-
-    def get_query(self):
-        return super(ContractBaseAdmin, self).get_query().outerjoin(ContractProperty).filter(
-            db.func.lower(ContractProperty.key) == 'spec number'
-        )
-
-    def get_count_query(self):
-        return super(ContractBaseAdmin, self).get_count_query().outerjoin(ContractProperty).filter(
-            db.func.lower(ContractProperty.key) == 'spec number'
-        )
 
 class ScoutContractAdmin(ContractBaseAdmin):
     inline_models = (ContractProperty, LineItem,)
@@ -61,10 +52,8 @@ class ScoutContractAdmin(ContractBaseAdmin):
     form_columns = [
         'contract_type', 'description', 'properties',
         'financial_id', 'expiration_date', 'contract_href',
-        'companies', 'followers', 'starred', 'is_archived'
+        'companies', 'followers', 'is_archived'
     ]
-
-    column_labels = dict(contract_href='Link to Contract PDF', financial_id='Controller #')
 
 class ConductorContractAdmin(ContractBaseAdmin):
     inline_models = (ContractProperty,)

--- a/purchasing/assets.py
+++ b/purchasing/assets.py
@@ -80,6 +80,7 @@ adminjs = Bundle(
     'libs/bootstrap/dist/js/bootstrap.js',
     'libs/bootstrap-datepicker/js/bootstrap-datepicker.js',
     'libs/select2/dist/js/select2.full.js',
+    'libs/moment/moment.js',
     filters='uglifyjs',
     output='public/js/admin.js'
 )

--- a/purchasing/data/contracts.py
+++ b/purchasing/data/contracts.py
@@ -2,6 +2,7 @@
 
 from purchasing.database import db
 from purchasing.data.models import ContractBase, ContractProperty
+from purchasing.opportunities.models import Opportunity
 
 from sqlalchemy.orm.session import make_transient
 

--- a/purchasing/data/models.py
+++ b/purchasing/data/models.py
@@ -180,7 +180,7 @@ class ContractProperty(Model):
 
     id = Column(db.Integer, primary_key=True, index=True)
     contract = db.relationship('ContractBase', backref=backref(
-        'properties', lazy='dynamic', cascade='all, delete-orphan'
+        'properties', lazy='subquery', cascade='all, delete-orphan'
     ))
     contract_id = ReferenceCol('contract', ondelete='CASCADE')
     key = Column(db.String(255), nullable=False)

--- a/purchasing_test/unit/factories.py
+++ b/purchasing_test/unit/factories.py
@@ -85,6 +85,7 @@ class ContractBaseFactory(BaseFactory):
         model = ContractBase
 
 class ContractPropertyFactory(BaseFactory):
+    id = factory.Sequence(lambda n: n + 10)
     contract = factory.SubFactory(ContractBase)
 
     class Meta:

--- a/purchasing_test/unit/util.py
+++ b/purchasing_test/unit/util.py
@@ -39,7 +39,7 @@ def get_a_property():
     if not contract:
         contract = insert_a_contract()
 
-    return contract.properties.first()
+    return contract.properties[0]
 
 def insert_a_stage(name='foo', send_notifs=False, post_opportunities=False):
     stage = StageFactory.create(**{


### PR DESCRIPTION
### What Changed
- Contract properties are exposed in the relevant admin pages
- You can search by contract properties
### Issues
- Fixes #237 
- Fixes #242 
### Screencap

![screen shot 2015-08-18 at 11 33 20 pm](https://cloud.githubusercontent.com/assets/1957344/9350022/a46a88f8-4601-11e5-99e7-33258a9d8a03.png)
