### PR TITLE
Fixed Beacon semantics and pending page

### DIFF
--- a/purchasing/opportunities/admin/views.py
+++ b/purchasing/opportunities/admin/views.py
@@ -42,7 +42,7 @@ def new():
         # strip the is_public field from the form data, it's not part of the form
         form_data.pop('is_public')
         opportunity = build_opportunity(form_data, publish=request.form.get('save_type'))
-        flash('Opportunity Successfully Created!', 'alert-success')
+        flash('Opportunity successfully created!', 'alert-success')
         return redirect(url_for('opportunities_admin.edit', opportunity_id=opportunity.id))
     return render_template(
         'opportunities/admin/opportunity.html', form=form, opportunity=None,
@@ -68,7 +68,7 @@ def edit(opportunity_id):
             # strip the is_public field from the form data, it's not part of the form
             form_data.pop('is_public')
             build_opportunity(form_data, publish=request.form.get('save_type'), opportunity=opportunity)
-            flash('Opportunity Successfully Created!', 'alert-success')
+            flash('Opportunity successfully updated!', 'alert-success')
             return redirect(url_for('opportunities_admin.edit', opportunity_id=opportunity.id))
 
         return render_template(

--- a/purchasing/opportunities/models.py
+++ b/purchasing/opportunities/models.py
@@ -146,12 +146,12 @@ class Opportunity(Model):
             {
                 'event': 'bid_open', 'classes': 'event event-open',
                 'date': self.estimate_open(),
-                'description': 'Opportunity opens for submissions.'
+                'description': 'We start accepting submissions.'
             },
             {
                 'event': 'deadline', 'classes': 'event event-deadline',
                 'date': self.estimate_deadline(),
-                'description': 'Deadline to submit proposals.'
+                'description': 'Deadline for submitting proposals.'
             }
         ]
 

--- a/purchasing/static/less/opportunities/_styles.less
+++ b/purchasing/static/less/opportunities/_styles.less
@@ -32,6 +32,7 @@ h4 {
   font-size: 24px;
 }
 
+
 .input-lg, .form-horizontal .form-group-lg .form-control {
   @media @mobile {
     font-size: 18px

--- a/purchasing/templates/opportunities/admin/opportunity.html
+++ b/purchasing/templates/opportunities/admin/opportunity.html
@@ -10,8 +10,10 @@
         {{ form.csrf_token() }}
         {% include "includes/flashes.html" %}
 
-        <h3>Advertise an Opportunity</h3>
-        <p>Fill out this form, and OMB will post your request to the City of Pittsburgh's new Opportunities website.</p>
+         <div class="spacer-20"></div>
+
+        <h4>Post an Opportunity</h4>
+        <h3>Fill out this form, and OMB will publish your opportunity to the City of Pittsburgh's new Opportunities website.</h3>
         {% if opportunity.id %}
         <p><a href="{{ url_for('opportunities.detail', opportunity_id=opportunity.id) }}">View this opportunity on Beacon.</a></p>
         {% endif %}
@@ -43,7 +45,7 @@
         <div class="row">
           <div class="col-sm-4">
             <div class="form-group">
-              <label for="planned_advertise" class="control-label">Advertise Date <span class="form-required">*</span></label>
+              <label for="planned_advertise" class="control-label">Publish Date <span class="form-required">*</span></label>
               <p class="help-block">
                 When do you want this opportunity to be made public? If you are uncertain, use an approximate date.
               </p>
@@ -53,7 +55,7 @@
 
           <div class="col-sm-4">
             <div class="form-group">
-              <label for="planned_open" class="control-label">Open Date <span class="form-required">*</span></label>
+              <label for="planned_open" class="control-label">Submission Start Date <span class="form-required">*</span></label>
               <p class="help-block">
                 When do you want to start receiving responses to this opportunity? If you are uncertain, use an approximate date.
               </p>
@@ -63,7 +65,7 @@
 
           <div class="col-sm-4">
             <div class="form-group">
-              <label for="planned_deadline" class="control-label">Planned Deadline <span class="form-required">*</span></label>
+              <label for="planned_deadline" class="control-label">Submission End Date <span class="form-required">*</span></label>
               <p class="help-block">
                 When is the deadline for vendors to respond to this opportunity? If you are uncertain, use an approximate date.
               </p>
@@ -83,11 +85,8 @@
         <div class="form-group">
           <label for="document" class="control-label">Upload your solicitation documents.</label>
           <p class="help-block">
-            If you don't have them on hand right now, don't worry. We'll email you two weeks before the publication date to remind you to upload it.
+            We accept .pdf, Word (.doc/.docx), and Excel (.xls/.xlsx) documents only.
           </p>
-          <p class="help-block"><strong>
-            .pdf, Word (.doc/.docx), and Excel (.xls/.xlsx) documents only!
-          </strong></p>
 
           {% if opportunity and opportunity.opportunity_documents.all()|length > 0 %}
             <p><strong>Uploaded files:</strong></p>
@@ -145,7 +144,7 @@
             </button>
             <ul class="dropdown-menu submit-dropdown">
               <li><a href="#" onclick="$('#save_type').val('save'); $('#js-opportunity-form').submit()">Save as draft</a></li>
-              <li><a href="#" onclick="$('#save_type').val('publish'); $('#js-opportunity-form').submit()">Save and publish on Advertise Date</a></li>
+              <li><a href="#" onclick="$('#save_type').val('publish'); $('#js-opportunity-form').submit()">Save and publish on Publish Date</a></li>
             </ul>
           </div>
         </div>

--- a/purchasing/templates/opportunities/admin/pending.html
+++ b/purchasing/templates/opportunities/admin/pending.html
@@ -40,15 +40,15 @@
 
             <div class="row">
               <div class="col-xs-4">
-                <h4>Planned Advertise Date</h4>
+                <h4>Planned publish date</h4>
+                <p>{{ opportunity.planned_advertise|datetimeformat('%m/%d/%y') }}</p>
+              </div>
+              <div class="col-xs-4">
+                <h4>Submission start date</h4>
                 <p>{{ opportunity.planned_open|datetimeformat('%m/%d/%y') }}</p>
               </div>
               <div class="col-xs-4">
-                <h4>Planned Open Date</h4>
-                <p>{{ opportunity.planned_deadline|datetimeformat('%m/%d/%y') }}</p>
-              </div>
-              <div class="col-xs-4">
-                <h4>Planned Deadline</h4>
+                <h4>Submission end date</h4>
                 <p>{{ opportunity.planned_deadline|datetimeformat('%m/%d/%y') }}</p>
               </div>
             </div><!-- dates -->

--- a/purchasing/templates/opportunities/browse.html
+++ b/purchasing/templates/opportunities/browse.html
@@ -24,7 +24,7 @@
 
         <h4>All Opportunities</h4>
 
-        <h3><strong>Currently accepting proposals</strong></h3>
+        <h3><strong>Current opportunities</strong></h3>
 
         {% if _open|length > 0 %}
         <div class="table-responsive">
@@ -34,7 +34,7 @@
                 <th>Select</th>
                 <th>Opportunity</th>
                 <th>Department</th>
-                <th>Deadline</th>
+                <th>Submissions close</th>
                 {% if not current_user.is_anonymous() %}
                 <th>Edit </th>
                 {% endif %}
@@ -60,7 +60,7 @@
 
         {% else %}
 
-        <p>There aren't any opportunities accepting proposals right now. <a href="{{ url_for('opportunities.signup') }}">Subscribe to our mailing list</a> and be among the first to know when upcoming opportunities become active ones.</p>
+        <p>There aren't any opportunities accepting submissions right now. <a href="{{ url_for('opportunities.signup') }}">Subscribe to our mailing list</a> and be among the first to know when upcoming opportunities become active ones.</p>
 
         {% endif %}
 
@@ -74,7 +74,7 @@
                 <th>Select</th>
                 <th>Opportunity</th>
                 <th>Department</th>
-                <th>Estimated open</th>
+                <th>Submissions start</th>
                 {% if not current_user.is_anonymous() %}
                 <th>Edit</th>
                 {% endif %}

--- a/purchasing/templates/opportunities/front/detail.html
+++ b/purchasing/templates/opportunities/front/detail.html
@@ -16,19 +16,18 @@
         {% if opportunity.can_edit(current_user) %}
         <p><a href="{{ url_for('opportunities_admin.edit', opportunity_id=opportunity.id) }}">Edit this opportunity</a></p>
         {% endif %}
-        {% if opportunity.categories|length > 0 %}
-
-        <div class="status status-complete">
+         <div class="status status-complete">
           {% if opportunity.is_upcoming %}
-          <p class="status-date"><strong>Opening soon!</strong> Accepting proposals starting {{ opportunity.estimate_open() }}</p>
+          <p class="status-date"><strong>Accepting submissions soon!</strong> Submit your responses starting on {{ opportunity.estimate_open() }}</p>
           {% elif opportunity.is_open %}
-          <h3>Open: accepting proposals</h3>
-          <p>Responses due by {{ opportunity.estimate_deadline() }}</p>
+          <h3>Accepting submissions</h3>
+          <p>Responses are due by {{ opportunity.estimate_deadline() }}</p>
           {% elif opportunity.is_closed %}
           <h3>Closed</h3>
-          <p>We are no longer accepting responses.</p>
+          <p>We are no longer accepting submissions.</p>
           {% endif %}
         </div>
+        {% if opportunity.categories|length > 0 %}
 
         <div class="row">
           <div class="col-md-10">
@@ -61,7 +60,7 @@
 
         {% if not opportunity.is_advertised %}
            <div class="alert alert-warning beacon-detail" role="alert">
-              This opportunity will not be viewable by the general public until advertised on {{ opportunity.planned_advertise.strftime('%B %d, %Y') }}
+              This opportunity will not be viewable by the general public until it's published on {{ opportunity.planned_advertise.strftime('%B %d, %Y') }}
           </div>
         {% endif %}
 
@@ -70,7 +69,7 @@
             <h3><strong>What is it?</strong></h3>
             <p>{{ opportunity.description }}</p>
             {% if opportunity.is_upcoming %}
-            <p><strong>We estimate that this opportunity will start accepting responses on {{ opportunity.estimate_open() }}.</strong></p>
+            <p><strong>We estimate that this opportunity will start accepting submissions on {{ opportunity.estimate_open() }}.</strong></p>
             {% endif %}
           </div>
         </div>

--- a/purchasing/templates/opportunities/front/signup.html
+++ b/purchasing/templates/opportunities/front/signup.html
@@ -27,7 +27,6 @@
 
         {% include 'opportunities/_categories.html' %}
 
-        <div class="spacer-20"></div>
 
         <label class="signup-label">What's your name?</label>
         <div class="form-group">

--- a/purchasing_test/unit/factories.py
+++ b/purchasing_test/unit/factories.py
@@ -98,7 +98,7 @@ class CategoryFactory(BaseFactory):
         model = Category
 
 class OpportunityFactory(BaseFactory):
-    id = factory.Sequence(lambda n: n)
+    id = factory.Sequence(lambda n: n + 100)
     department = factory.SubFactory(DepartmentFactory)
 
     class Meta:

--- a/purchasing_test/unit/opportunities/test_opportunity_admin.py
+++ b/purchasing_test/unit/opportunities/test_opportunity_admin.py
@@ -206,7 +206,7 @@ class TestOpportunitiesAdmin(TestOpportunitiesAdminBase):
         new_contract = self.client.post('/beacon/admin/opportunities/new', data=bad_data)
 
         self.assertEquals(Opportunity.query.count(), 5)
-        self.assert_flashes('Opportunity Successfully Created!', 'alert-success')
+        self.assert_flashes('Opportunity successfully created!', 'alert-success')
 
         self.assertFalse(
             Opportunity.query.filter(Opportunity.description == 'Just right.').first().is_public


### PR DESCRIPTION
#### What Changed
- Fixes copy on Beacon in #261
- Fixes #265 
- Also fixes opportunity status display, so that status is shown whether or not opportunity has categories associated with it (edge case)
#### What's needed
- Fix models
#### Screenshots

Detail page:
![screen shot 2015-08-24 at 2 55 11 pm](https://cloud.githubusercontent.com/assets/1178390/9453703/fcd4ed30-4a70-11e5-8883-4b94ad6f212b.png)

Add opportunity page:
![screen shot 2015-08-24 at 2 34 53 pm](https://cloud.githubusercontent.com/assets/1178390/9453707/0533511a-4a71-11e5-8691-dd05f9fcd31e.png)

Preview page:
![screen shot 2015-08-24 at 2 33 29 pm](https://cloud.githubusercontent.com/assets/1178390/9453714/149ec3c8-4a71-11e5-807c-2d812686b32e.png)

Pending page:
![screen shot 2015-08-24 at 2 34 22 pm](https://cloud.githubusercontent.com/assets/1178390/9453713/149c1696-4a71-11e5-840a-feb19fc2cd5d.png)
