### PR TITLE
Quick Beacon fix: display correct date on browse page

### DIFF
--- a/purchasing/templates/opportunities/browse.html
+++ b/purchasing/templates/opportunities/browse.html
@@ -34,7 +34,7 @@
                 <th>Select</th>
                 <th>Opportunity</th>
                 <th>Department</th>
-                <th>Submissions close</th>
+                <th>Respond by</th>
                 {% if not current_user.is_anonymous() %}
                 <th>Edit </th>
                 {% endif %}
@@ -64,7 +64,7 @@
 
         {% endif %}
 
-        <h3><strong>Upcoming opportunities</strong></h3>
+        <h3><strong>Respond starting</strong></h3>
 
         {% if upcoming|length > 0 %}
         <div class="table-responsive">
@@ -74,7 +74,7 @@
                 <th>Select</th>
                 <th>Opportunity</th>
                 <th>Department</th>
-                <th>Submissions start</th>
+                <th>Respond starting</th>
                 {% if not current_user.is_anonymous() %}
                 <th>Edit</th>
                 {% endif %}
@@ -86,7 +86,7 @@
                 <td class="col-md-1"><input type="checkbox" name="opportunity" value="{{ opportunity.id }}"></td>
                 <td class="col-md-5"><a href="{{ url_for('opportunities.detail', opportunity_id=opportunity.id) }}">{{ opportunity.title }}</a></td>
                 <td class="col-md-3">{{ opportunity.department }}</td>
-                <td class="col-md-2">{{ opportunity.planned_deadline|datetimeformat('%m/%d/%y') }}</td>
+                <td class="col-md-2">{{ opportunity.planned_open|datetimeformat('%m/%d/%y') }}</td>
                 {% if opportunity.can_edit(current_user) %}
                 <td><a href="{{ url_for('opportunities_admin.edit', opportunity_id=opportunity.id) }}">Edit</a></td>
                 {% elif not current_user.is_anonymous() %}

--- a/purchasing/templates/opportunities/browse.html
+++ b/purchasing/templates/opportunities/browse.html
@@ -64,7 +64,7 @@
 
         {% endif %}
 
-        <h3><strong>Respond starting</strong></h3>
+        <h3><strong>Upcoming opportunities</strong></h3>
 
         {% if upcoming|length > 0 %}
         <div class="table-responsive">


### PR DESCRIPTION
#### What changed
- Fixes #307 
- Changed "Submission starts" column title to "Respond starting" since that phrase probs make more sense to businesses
- Changed "Submissions close" to "Respond by" to match the "Respond starting" copy
#### What's Needed
- N/A
#### Screenshots

Date displayed is now the date people can start sending in submissions. 

![screen shot 2015-08-27 at 5 49 06 pm](https://cloud.githubusercontent.com/assets/1178390/9536724/177fd60c-4ce4-11e5-806e-979c92595331.png)
