### PR TITLE
Streamline install process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ env
 
 # Bower Installs
 libs/
+node_modules/
 
 # Flask-assets output
 css

--- a/Makefile
+++ b/Makefile
@@ -7,3 +7,4 @@ setup:
 	make install
 	python manage.py db upgrade
 	python manage.py seed_user -e $(ADMIN_EMAIL) -r 1
+	python manage.py seed

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 install:
 	pip install -r requirements/dev.txt
+	npm install
 	bower install
 
 setup:
 	make install
-	createdb purchasing
+	python manage.py db upgrade
 	python manage.py seed_user -e $(ADMIN_EMAIL) -r 1
-	python manage.py seed

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+install:
+	pip install -r requirements/dev.txt
+	bower install
+
+setup:
+	make install
+	createdb purchasing
+	python manage.py seed_user -e $(ADMIN_EMAIL) -r 1
+	python manage.py seed

--- a/README.md
+++ b/README.md
@@ -22,13 +22,37 @@ Core Pittsburgh Purchasing Suite features are in alpha, with other features in d
 The purchasing suite is a project of the 2015 Pittsburgh Code for America [fellowship team](http://codeforamerica.org/governments/pittsburgh).
 
 ## How
+
 #### Core Dependencies
 The purchasing suite is a [Flask](http://flask.pocoo.org/) app. It uses [Postgres](http://www.postgresql.org/) for a database and uses [bower](http://bower.io/) to manage most of its dependencies. It also uses [less](http://lesscss.org/) to compile style assets. In production, the project uses [Celery](http://celery.readthedocs.org/en/latest/) with [Redis](http://redis.io/) as a broker to handle backgrounding various tasks. Big thanks to the [cookiecutter-flask](https://github.com/sloria/cookiecutter-flask) project for a nice kickstart.
 
 It is highly recommended that you use use [virtualenv](https://readthedocs.org/projects/virtualenv/) (and [virtualenvwrapper](https://virtualenvwrapper.readthedocs.org/en/latest/) for convenience). For a how-to on getting set up, please consult this [howto](https://github.com/codeforamerica/howto/blob/master/Python-Virtualenv.md). Additionally, you'll need node to install bower (see this [howto](https://github.com/codeforamerica/howto/blob/master/Node.js.md) for more on Node), and it is recommended that you use [postgres.app](http://postgresapp.com/) to handle your Postgres (assuming you are developing on OSX).
 
-#### Developing the Pittsburgh Purchasing Suite
-Use the following commands to bootstrap your development environment:
+#### Installation and setup
+
+##### Quick local installation using Make
+
+First, create a virtualenv and activate it. Then:
+
+```bash
+git clone git@github.com:codeforamerica/pittsburgh-purchasing-suite.git
+# create the 'purchasing' database
+psql -c 'create database purchasing;'
+# set environmental variables - it is recommended that you set these for your
+# your virtualenv, using a tool like autoenv or by modifying your activate script
+export ADMIN_EMAIL='youremail@someplace.net'
+export CONFIG=purchasing.settings.DevConfig
+# this next command will do all installs, add tables to the database, 
+# and insert seed data (note that this needs an internet connection to
+# scrape data from Allegheny County)
+make setup
+# start your server
+python manage.py server
+```
+
+##### More detailed installation instructions
+
+If you want to walk through the complete setup captured above in `make setup`, use the following commands to bootstrap your development environment:
 
 **python app**:
 

--- a/bower.json
+++ b/bower.json
@@ -2,8 +2,8 @@
   "name": "pittsburgh-purchasing-suite",
   "dependencies": {
     "bootstrap": "~3.2.0",
-    "jQuery": "~1.11.0",
     "bootstrap-datepicker": "~1.4.0",
+    "jquery": "~1.11.0",
     "datatables": "~1.10.7",
     "html5shiv": "~3.7.3",
     "respond": "~1.4.2",

--- a/manage.py
+++ b/manage.py
@@ -38,9 +38,12 @@ def seed_user(email, role, dept):
     '''
     Creates a new user in the database.
     '''
-    from purchasing.users.models import User
+    from purchasing.users.models import User, Department
     seed_email = email if email else app.config.get('SEED_EMAIL')
     user_exists = User.query.filter(User.email == seed_email).first()
+    department = Department.query.filter(
+            Department.name == db.func.lower(dept)
+            ).first()
     if user_exists:
         print 'User {email} already exists'.format(email=seed_email)
     else:
@@ -49,7 +52,7 @@ def seed_user(email, role, dept):
                 email=seed_email,
                 created_at=datetime.datetime.utcnow(),
                 role_id=role,
-                department=dept
+                department=department if department else None
             )
             db.session.add(new_user)
             db.session.commit()

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "private": true,
+  "license": "ISC",
+  "homepage": "https://github.com/codeforamerica/pittsburgh-purchasing-suite#readme",
+  "dependencies": {
+    "less": "^2.5.1",
+    "uglifyjs": "^2.4.10"
+  }
+}

--- a/purchasing/settings.py
+++ b/purchasing/settings.py
@@ -3,14 +3,15 @@ import os
 
 HERE = os.path.abspath(os.path.dirname(__file__))
 os_env = os.environ
+PROJECT_ROOT = os.path.abspath(os.path.join(HERE, os.pardir))
 
 class Config(object):
     SECRET_KEY = os_env.get('PITTSBURGH-PURCHASING-SUITE_SECRET', 'secret-key')  # TODO: Change me
-    APP_DIR = os.path.abspath(os.path.dirname(__file__))  # This directory
-    PROJECT_ROOT = os.path.abspath(os.path.join(APP_DIR, os.pardir))
+    APP_DIR = HERE
     ASSETS_DEBUG = False
     DEBUG_TB_ENABLED = False  # Disable Debug toolbar
     DEBUG_TB_INTERCEPT_REDIRECTS = False
+    PROJECT_ROOT = PROJECT_ROOT
     CACHE_TYPE = 'simple'  # Can be "memcached", "redis", etc.
     BROWSERID_URL = os_env.get('BROWSERID_URL')
     PER_PAGE = 50
@@ -64,6 +65,8 @@ class DevConfig(Config):
     # CELERY_BROKER_URL = os_env.get('REDIS_URL', 'redis://localhost:6379/0')
     # CELERY_RESULT_BACKEND = os_env.get('REDIS_URL', 'redis://localhost:6379/0')
     CELERY_ALWAYS_EAGER = True
+    UGLIFYJS_BIN = os.path.join(PROJECT_ROOT, 'node_modules', '.bin', 'uglifyjs')
+    LESS_BIN = os.path.join(PROJECT_ROOT, 'node_modules', '.bin', 'lessc')
 
 class TestConfig(Config):
     ADMIN_EMAIL = 'foo@foo.com'


### PR DESCRIPTION
This branch reduces the number of steps to get the app up and running from scratch.
It changes installs, and adds a Makefile with the `make setup` shortcut to get everything running.
It allows the following install and setup process (also written in README.md):

---
##### Quick local installation using Make

First, create a virtualenv and activate it. Then:

``` bash
git clone git@github.com:codeforamerica/pittsburgh-purchasing-suite.git
# create the 'purchasing' database
psql -c 'create database purchasing;'
# set environmental variables - it is recommended that you set these for your
# your virtualenv, using a tool like autoenv or by modifying your activate script
export ADMIN_EMAIL='youremail@someplace.net'
export CONFIG=purchasing.settings.DevConfig
# this next command will do all installs, add tables to the database, 
# and insert seed data (note that this needs an internet connection to
# scrape data from Allegheny County)
make setup
# start your server
python manage.py server
```
