### PR TITLE
use completed date for conductor, fixes #411

### DIFF
--- a/purchasing/templates/conductor/detail/event_well.html
+++ b/purchasing/templates/conductor/detail/event_well.html
@@ -23,7 +23,7 @@
   {% if stage.entered and stage.exited %}
     <div class="event event-complete {% if stage.id == active_stage.id %}event-active{% endif %}">
       <p><a href="{{ url_for('conductor.detail', contract_id=stage.contract_id, stage_id=stage.id) }}">{{ stage.name }}</a></p>
-      <p class="event-date"><small>Completed {{ format_days_from_today(stage.exited)|lower }} ({{ stage.entered|datetimeformat('%m/%d/%y') }})</small></p>
+      <p class="event-date"><small>Completed {{ format_days_from_today(stage.exited)|lower }} ({{ stage.exited|datetimeformat('%m/%d/%y') }})</small></p>
       <p class="text-muted"><small>Took
         {% if stage.days_spent > 0 %}{{ stage.days_spent|int }} days
         {% else %}{{ stage.hours_spent|int }} hours


### PR DESCRIPTION
Before:

![screen shot 2015-09-21 at 2 33 55 pm](https://cloud.githubusercontent.com/assets/1957344/10005735/d27dd6ec-606d-11e5-8cc9-625fa05892d6.png)

After:

![screen shot 2015-09-21 at 2 34 02 pm](https://cloud.githubusercontent.com/assets/1957344/10005736/d48057f8-606d-11e5-97e3-401087c92b5d.png)
