### PR TITLE
Conductor email improvements

### DIFF
--- a/purchasing/conductor/manager/views.py
+++ b/purchasing/conductor/manager/views.py
@@ -431,7 +431,8 @@ def edit_company_contacts(contract_id):
 
             Notification(
                 to_email=[i.email for i in contract.followers],
-                from_email=current_user.email,
+                from_email=current_app.config['CONDUCTOR_SENDER'],
+                reply_to=current_user.email,
                 subject='A contract you follow has been updated!',
                 html_template='conductor/emails/new_contract.html',
                 contract=main_contract

--- a/purchasing/conductor/manager/views.py
+++ b/purchasing/conductor/manager/views.py
@@ -28,8 +28,7 @@ from purchasing.conductor.forms import (
 )
 
 from purchasing.conductor.util import (
-    update_contract_with_spec, handle_form, ContractMetadataObj,
-    build_subscribers, create_opp_form_obj,
+    handle_form, ContractMetadataObj, build_subscribers, create_opp_form_obj,
     json_serial, parse_companies, UpdateFormObj, assign_a_contract
 )
 
@@ -360,7 +359,7 @@ def edit(contract_id):
             else:
                 # if there is no flow, that means that it is an extended contract
                 # so we will save it and return back to the conductor home page
-                contract, _ = update_contract_with_spec(contract, form.data)
+                contract.update_with_spec_number(form.data)
                 current_app.logger.info('CONDUCTOR CONTRACT COMPLETE - contract metadata for "{}" updated'.format(
                     contract.description
                 ))
@@ -417,10 +416,11 @@ def edit_company_contacts(contract_id):
                     contact, _ = get_or_create(db.session, CompanyContact, **_contact)
 
                 contract_data['financial_id'] = _company['financial_id']
-                contract, _ = update_contract_with_spec(
-                    contract, contract_data,
-                    company=company, clone=(ix > 0),
-                )
+                if ix == 0:
+                    contract.update_with_spec_number(contract_data, company=company)
+                else:
+                    contract = ContractBase.clone(contract, parent_id=contract.parent_id, strip=False)
+                    contract.update_with_spec_number(contract_data, company=company)
 
                 contract.is_visible = True
                 contract.parent.is_archived = True

--- a/purchasing/conductor/util.py
+++ b/purchasing/conductor/util.py
@@ -36,6 +36,7 @@ class OpportunityFormObj(object):
 
 class UpdateFormObj(object):
     def __init__(self, stage):
+        self.send_to_cc = current_user.email
         self.body = stage.default_message if stage.default_message else ''
 
 def json_serial(obj):
@@ -111,7 +112,7 @@ def handle_form(form, form_name, stage_id, user, contract, current_stage):
 
             Notification(
                 to_email=[i.strip() for i in form.data.get('send_to').split(';') if i != ''],
-                from_email='conductorbot@buildpgh.com',
+                from_email=current_app.config['CONDUCTOR_SENDER'],
                 reply_to=current_user.email,
                 cc_email=form.data.get('send_to_cc', []),
                 subject=form.data.get('subject'),

--- a/purchasing/data/contracts.py
+++ b/purchasing/data/contracts.py
@@ -87,6 +87,25 @@ class ContractBase(RefreshSearchViewMixin, Model):
         except IndexError:
             return ContractProperty()
 
+    def update_with_spec_number(self, data, company=None):
+        spec_number = self.get_spec_number()
+
+        new_spec = data.pop('spec_number', None)
+        if new_spec:
+            spec_number.key = 'Spec Number'
+            spec_number.value = new_spec
+        else:
+            spec_number.key = 'Spec Number'
+            spec_number.value = None
+        self.properties.append(spec_number)
+
+        if company:
+            self.companies.append(company)
+
+        self.update(**data)
+
+        return spec_number
+
     def build_complete_action_log(self):
         '''Returns the complete action log for this contract
         '''

--- a/purchasing/opportunities/front/views.py
+++ b/purchasing/opportunities/front/views.py
@@ -78,6 +78,7 @@ def signup():
 
                 confirmation_sent = Notification(
                     to_email=vendor.email, subject='Thank you for signing up!',
+                    from_email=current_app.config['BEACON_SENDER'],
                     html_template='opportunities/emails/signup.html',
                     txt_template='opportunities/emails/signup.txt',
                     categories=form_data['categories']
@@ -90,6 +91,7 @@ def signup():
 
                     Notification(
                         to_email=admins, subject='A new vendor has signed up on beacon',
+                        from_email=current_app.config['BEACON_SENDER'],
                         categories=form_data['categories'],
                         vendor=form_data['email'], convert_args=True,
                         business_name=form_data['business_name']
@@ -252,6 +254,7 @@ def signup_for_opp(form, user, opportunity, multi=False):
 
     Notification(
         to_email=vendor.email,
+        from_email=current_app.config['BEACON_SENDER'],
         subject='Subscription confirmation from Beacon',
         html_template='opportunities/emails/oppselected.html',
         txt_template='opportunities/emails/oppselected.txt',

--- a/purchasing/opportunities/util.py
+++ b/purchasing/opportunities/util.py
@@ -186,6 +186,7 @@ def build_opportunity(data, publish=None, opportunity=None):
             # saving a draft as opposed to publishing the opportunity
             Notification(
                 to_email=[current_user.email],
+                from_email=current_app.config['BEACON_SENDER'],
                 subject='Your post has been sent to OMB for approval',
                 html_template='opportunities/emails/staff_postsubmitted.html',
                 txt_template='opportunities/emails/staff_postsubmitted.txt',
@@ -196,6 +197,7 @@ def build_opportunity(data, publish=None, opportunity=None):
                 to_email=db.session.query(User.email).join(Role, User.role_id == Role.id).filter(
                     Role.name.in_(['admin', 'superadmin'])
                 ).all(),
+                from_email=current_app.config['BEACON_SENDER'],
                 subject='A new Beacon post needs review',
                 html_template='opportunities/emails/admin_postforapproval.html',
                 txt_template='opportunities/emails/admin_postforapproval.txt',
@@ -236,6 +238,7 @@ def send_publish_email(opportunity):
 
         Notification(
             to_email=[i.email for i in vendors],
+            from_email=current_app.config['BEACON_SENDER'],
             subject='A new City of Pittsburgh opportunity from Beacon!',
             html_template='opportunities/emails/newopp.html',
             txt_template='opportunities/emails/newopp.txt',

--- a/purchasing/settings.py
+++ b/purchasing/settings.py
@@ -17,7 +17,9 @@ class Config(object):
     PER_PAGE = 50
     CITY_DOMAIN = 'pittsburghpa.gov'
     ADMIN_EMAIL = os_env.get('ADMIN_EMAIL', 'bsmithgall@codeforamerica.org')
-    MAIL_DEFAULT_SENDER = 'beaconbot@pittsburghpurchasingsuite.com'
+    MAIL_DEFAULT_SENDER = os_env.get('MAIL_DEFAULT_SENDER', 'no-reply@buildpgh.com')
+    BEACON_SENDER = os_env.get('BEACON_SENDER', 'beaconbot@buildpgh.com')
+    CONDUCTOR_SENDER = os_env.get('CONDUCTOR_SENDER', 'conductorbot@buildpgh.com')
     MAIL_PORT = 587
     MAIL_USE_TLS = True
     UPLOAD_S3 = True

--- a/purchasing/tasks.py
+++ b/purchasing/tasks.py
@@ -12,7 +12,7 @@ def send_email(messages, multi):
             for message in messages:
                 conn.send(message)
     else:
-        mail.send(messages[0])
+        mail.send(messages)
 
 @celery.task
 def rebuild_search_view():

--- a/purchasing/templates/wexplorer/contract.html
+++ b/purchasing/templates/wexplorer/contract.html
@@ -93,7 +93,7 @@
         <p class="wexplorer-column-header">Departments Following</p>
         {% if contract.followers | length > 0 %}
         <ul>
-        {% for department in departments %}
+        {% for department in departments if department %}
           <li>
             <a href="{{ url_for('wexplorer.filter', department_id=department.id) }}">
               {{ department.name }}


### PR DESCRIPTION
### What Changed
- Send conductor emails from a configurable CONDUCTOR_SENDER and beacon emails from a configurable BEACON_SENDER (set now to conductorbot@buildpgh.com and beaconbot@buildpgh.com, respectively)
- Use a reply-to header in conductor to allow emails to be delivered properly.
- Auto-append the current user's email to the send_to_cc field in conductor
### Issues
- Fixes #418 
- Fixes #419 
