### PR TITLE
Conductor bugfixes

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,7 @@
     "html5shiv": "~3.7.3",
     "jquery": "~1.11.0",
     "jquery-ui": "~1.11.4",
+    "jquery.dirtyforms": "~1.2.3",
     "moment": "~2.10.6",
     "respond": "~1.4.2",
     "select2": "~4.0.0"

--- a/purchasing/app.py
+++ b/purchasing/app.py
@@ -24,7 +24,8 @@ from purchasing.extensions import (
 from purchasing.users.models import AnonymousUser
 from purchasing.filters import (
     url_for_other_page, thispage, format_currency, better_title,
-    days_from_today, datetimeformat, format_days_from_today
+    days_from_today, datetimeformat, format_days_from_today,
+    newline_to_br
 )
 
 # import models so that flask-migrate can auto-detect
@@ -126,6 +127,7 @@ def register_jinja_extensions(app):
     app.jinja_env.filters['currency'] = format_currency
     app.jinja_env.filters['title'] = better_title
     app.jinja_env.filters['datetimeformat'] = datetimeformat
+    app.jinja_env.filters['newline_to_br'] = newline_to_br
     return None
 
 def register_errorhandlers(app):

--- a/purchasing/assets.py
+++ b/purchasing/assets.py
@@ -68,6 +68,7 @@ wexplorerjs = Bundle(
 
 conductorjs = Bundle(
     'libs/datatables/media/js/jquery.dataTables.js',
+    'libs/jquery.dirtyforms/jquery.dirtyforms.js',
     'libs/select2/dist/js/select2.js',
     'js/shared/*.js',
     'js/conductor/*.js',

--- a/purchasing/static/js/conductor/detail.js
+++ b/purchasing/static/js/conductor/detail.js
@@ -13,16 +13,6 @@
 
   $('.js-filter-btn').on('click', function(e) {
 
-    // var _this = $(this);
-    // _this.attr('data-show') = _this.attr('data-show') === 'show' ? 'show' : 'hide';
-    // // $('.js-filter-btn').filter('data-show') === 'show';
-    // var toFilter = 'js-filter-action-' + _this.attr('data-js-filter');
-    // if (toFilter != 'js-filter-action-clear') {
-    //   $('.' + toFilter).show();
-    // } else {
-    //   $('.action-event').show();
-    // }
-
     // get the classname to show/hide
 
     // show or hide that specific classname
@@ -47,5 +37,7 @@
     }
 
   });
+
+  $('#js-send-email-update-form').dirtyForms();
 
 })();

--- a/purchasing/tasks.py
+++ b/purchasing/tasks.py
@@ -6,13 +6,10 @@ from purchasing.extensions import mail, db, cache
 from purchasing.data.importer.scrape_county import main as scrape_county
 
 @celery.task
-def send_email(messages, multi):
-    if multi:
-        with mail.connect() as conn:
-            for message in messages:
-                conn.send(message)
-    else:
-        mail.send(messages)
+def send_email(messages):
+    with mail.connect() as conn:
+        for message in messages:
+            conn.send(message)
 
 @celery.task
 def rebuild_search_view():

--- a/purchasing/templates/conductor/detail/_add_note.html
+++ b/purchasing/templates/conductor/detail/_add_note.html
@@ -1,5 +1,5 @@
 {% import "macros/with_errors.html" as macros %}
-<form class="form form-horizontal" method="POST" action="{{ url_for('conductor.detail', contract_id=contract.id, stage_id=active_stage.id, form='activity') }}">
+<form class="form form-horizontal" method="POST" action="{{ url_for('conductor.detail', contract_id=contract.id, stage_id=active_stage.id, form='activity') }}" id="js-conductor-note-form">
   {{ note_form.csrf_token() }}
   <div class="form-group">
     <label for="description" class="control-label col-sm-2">Add Note</label>

--- a/purchasing/templates/conductor/detail/_post_opportunities.html
+++ b/purchasing/templates/conductor/detail/_post_opportunities.html
@@ -2,7 +2,7 @@
 
 <div class="row">
   <div class="col-md-12">
-    <form method="POST" enctype="multipart/form-data" action="{{ url_for('conductor.detail', contract_id=contract.id, stage_id=active_stage.id, form='post') }}">
+    <form method="POST" enctype="multipart/form-data" action="{{ url_for('conductor.detail', contract_id=contract.id, stage_id=active_stage.id, form='post') }}" id="js-conductor-post-opportunity-form">
 
       {% set form = opportunity_form %}
       {{ form.csrf_token() }}

--- a/purchasing/templates/conductor/detail/_send_updates.html
+++ b/purchasing/templates/conductor/detail/_send_updates.html
@@ -1,6 +1,6 @@
 {% import "macros/with_errors.html" as macros %}
 
-<form class="form form-horizontal" method="POST" action="{{ url_for('conductor.detail', contract_id=contract.id, stage_id=active_stage.id, form='update') }}" enctype="multipart/form-data">
+<form class="form form-horizontal" method="POST" action="{{ url_for('conductor.detail', contract_id=contract.id, stage_id=active_stage.id, form='update') }}" enctype="multipart/form-data" id="js-send-email-update-form">
 
   <div class="form-group">
     <div class="row">

--- a/purchasing/templates/conductor/detail/_update_metadata.html
+++ b/purchasing/templates/conductor/detail/_update_metadata.html
@@ -1,6 +1,6 @@
 {% import "macros/with_errors.html" as macros %}
 
-<form class="form form-horizontal" method="POST" action="{{ url_for('conductor.detail', contract_id=contract.id, stage_id=active_stage.id, form='update-metadata') }}">
+<form class="form form-horizontal" method="POST" action="{{ url_for('conductor.detail', contract_id=contract.id, stage_id=active_stage.id, form='update-metadata') }}" id="js-conductor-update-metadata-form">
 
   {% if metadata_form.errors['all_blank'] %}
   <div class="alert alert-danger alert-dismissible" role="alert">

--- a/purchasing/templates/conductor/emails/email_update.html
+++ b/purchasing/templates/conductor/emails/email_update.html
@@ -1,1 +1,1 @@
-{{ body }}
+{{ body|newline_to_br }}

--- a/purchasing_test/unit/other/test_filters.py
+++ b/purchasing_test/unit/other/test_filters.py
@@ -10,7 +10,7 @@ from flask_testing import TestCase as FlaskTestCase
 from purchasing.app import create_app as _create_app
 from purchasing.filters import (
     better_title, format_currency, days_from_today,
-    datetimeformat, format_days_from_today
+    datetimeformat, format_days_from_today, newline_to_br
 )
 
 class TestFilters(TestCase):
@@ -77,3 +77,14 @@ class TestDateTimeFormat(FlaskTestCase):
         self.assertEquals(datetimeformat('2015-01-01T00:00:01'), '2014-12-31')
         self.assertEquals(datetimeformat('2015-01-01T00:00:00'), '2015-01-01')
         self.assertEquals(datetimeformat(None), '')
+
+    def test_newline_to_br(self):
+        self.assertEquals(
+            newline_to_br(None, 'test\r\n\r\ntest\r\n\r\ntest'),
+            '<p>test</p>\n\n<p>test</p>\n\n<p>test</p>'
+        )
+        self.assertEquals(
+            newline_to_br(None, 'test\ntest\r\n\r\ntest\r\n\r\ntest'),
+            '<p>test<br>\ntest</p>\n\n<p>test</p>\n\n<p>test</p>'
+        )
+

--- a/purchasing_test/unit/other/test_notifications.py
+++ b/purchasing_test/unit/other/test_notifications.py
@@ -14,10 +14,12 @@ class TestNotification(TestCase):
     def test_notification_initialization(self, render_template):
         '''Test notifications properly initialize
         '''
-        notification = Notification(from_email='foo@foo.com')
-        self.assertEquals(notification.to_email, [])
+        notification = Notification(
+            from_email='foo@foo.com', to_email='foobar@bar.com', cc_email=[('bazbar@bar.com',), ('foobar@foo.com',)]
+        )
+        self.assertEquals(notification.to_email, ['foobar@bar.com'])
         self.assertEquals(notification.from_email, 'foo@foo.com')
-        self.assertEquals(notification.cc_email, [])
+        self.assertEquals(notification.cc_email, ['bazbar@bar.com', 'foobar@foo.com'])
         self.assertEquals(notification.subject, '')
         self.assertEquals(notification.html_body, 'a test')
         self.assertEquals(notification.txt_body, '')


### PR DESCRIPTION
### What Changed
- Fixed bug with CC emails being incorrectly split into a bunch of individual letter strings
- Added new jinja filter to automatically convert `\r\n` characters into `p` tags, preserving spacing in HTML emails
- Added new front-end dependency: `jquery-dirtyforms` to prevent accidental data loss on the email send form
### Issues
- Fixes #428 
- Fixes #417 
- Fixes #425 

**Note:** issues relating to UI/CSS/layout will be handled in a separate pull request. This is just to capture bugfixes so that we can deploy a fix more quickly.
### Screenshots

Email:
![screen shot 2015-09-23 at 2 33 29 pm](https://cloud.githubusercontent.com/assets/1957344/10059490/183f550a-6200-11e5-8058-4023240db51b.png)

Dirty forms:
![screen shot 2015-09-23 at 1 43 13 pm](https://cloud.githubusercontent.com/assets/1957344/10059493/1cdc8114-6200-11e5-9fd6-5a3b2a439c78.png)
