### PR TITLE
fix recipient bug -- closes #451

### DIFF
--- a/purchasing/jobs/beacon_nightly.py
+++ b/purchasing/jobs/beacon_nightly.py
@@ -24,6 +24,7 @@ class BeaconNewOppotunityOpenJob(EmailJobBase):
             notifications.append(
                 Notification(
                     to_email=set([i.email for i in category_vendors] + [i.email for i in opportunity.vendors]),
+                    cc_email=list(),
                     from_email=current_app.config['BEACON_SENDER'],
                     subject='A new City of Pittsburgh opportunity from Beacon!',
                     html_template='opportunities/emails/newopp.html',

--- a/purchasing/notifications.py
+++ b/purchasing/notifications.py
@@ -86,7 +86,7 @@ class Notification(object):
                 subject='[Pittsburgh Purchasing] {}'.format(self.subject),
                 html=self.html_body, body=self.txt_body,
                 sender=self.from_email, reply_to=self.reply_to,
-                recipients=self.to_email, cc=self.cc_email
+                recipients=self.handle_recipients(recipient), cc=self.cc_email
             )
 
             for attachment in self.attachments:
@@ -110,14 +110,18 @@ class Notification(object):
             )
             return False
 
-    def send(self, multi=False, async=True):
-
+    def _build(self, multi=False):
         msgs = []
         if multi:
             for to in self.to_email:
                 msgs.append(self.build_msg(to))
         else:
             msgs.append(self.build_msg(self.to_email))
+
+        return msgs
+
+    def send(self, multi=False, async=True):
+        msgs = self._build(multi)
 
         if async:
             send_email.delay(msgs)


### PR DESCRIPTION
- quick postmortem: part of the conductor change involved a rewrite of some of the Notification class code. When this happened, I made a change that would cause the whole "to" list to receive the emails. The change is here: https://github.com/codeforamerica/pittsburgh-purchasing-suite/pull/432/files#diff-fc720a98fbaf940853be442407c0de08R89. This was a bug introduced in that patch.
- I have added two test cases to mitigate against this in the future; one that checks that a "non-multi" or single email will glob all of the recipients into one Message object, and one that will make sure that a multi message separates the recipients into multiple messages
