### PR TITLE
added more obvious form vaidation

### DIFF
--- a/purchasing/opportunities/forms.py
+++ b/purchasing/opportunities/forms.py
@@ -172,6 +172,7 @@ class CategoryForm(Form):
         subcategories = self.build_categories(all_categories)
         self._subcategories = json.dumps(subcategories)
         display_categories = subcategories.keys()
+
         if 'Select All' in display_categories:
             display_categories.remove('Select All')
         self._categories = json.dumps(sorted(display_categories))
@@ -196,9 +197,6 @@ class CategoryForm(Form):
                         self.errors['subcategories'] = ['{} is not a valid choice!'.format(subcat)]
                         break
                     self.categories.data.add(subcat)
-
-        if len(subcats) == 0 and not self.errors.get('subcategories', None):
-            self.errors['categories'] = ['You must choose at least one!']
 
 class VendorSignupForm(CategoryForm):
     business_name = fields.TextField(validators=[DataRequired()])
@@ -231,12 +229,11 @@ class UnsubscribeForm(Form):
     )
 
 class OpportunityDocumentForm(NoCSRFForm):
-    title = fields.TextField(validators=[RequiredIf('document')])
-    document = FileField(
-        validators=[FileAllowed(
-            ['pdf', 'doc', 'docx', 'xls', 'xlsx'],
-            '.pdf, Word (.doc/.docx), and Excel (.xls/.xlsx) documents only!')
-        ]
+    title = fields.TextField(label='Document Name', validators=[RequiredIf('document')])
+    document = FileField('Document', validators=[FileAllowed(
+        ['pdf', 'doc', 'docx', 'xls', 'xlsx'],
+        '.pdf, Word (.doc/.docx), and Excel (.xls/.xlsx) documents only!'),
+        RequiredIf('title')]
     )
 
     def upload_document(self, _id):
@@ -278,13 +275,15 @@ class OpportunityForm(CategoryForm):
         query_factory=Department.query_factory,
         get_pk=lambda i: i.id,
         get_label=lambda i: i.name,
-        allow_blank=True, blank_text='-----'
+        allow_blank=True, blank_text='-----',
+        validators=[DataRequired()]
     )
     opportunity_type = QuerySelectField(
         query_factory=ContractType.opportunity_type_query,
         get_pk=lambda i: i.id,
         get_label=lambda i: i.name,
-        allow_blank=True, blank_text='-----'
+        allow_blank=True, blank_text='-----',
+        validators=[DataRequired()]
     )
     contact_email = fields.TextField(validators=[Email(), city_domain_email, DataRequired()])
     title = fields.TextField(validators=[DataRequired()])
@@ -302,7 +301,8 @@ class OpportunityForm(CategoryForm):
 
     def display_cleanup(self, opportunity=None):
         self.vendor_documents_needed.choices = [i.get_choices() for i in RequiredBidDocument.query.all()]
-        self.contact_email.data = opportunity.contact.email if opportunity else ''
+        if opportunity and not self.contact_email.data:
+            self.contact_email.data = opportunity.contact.email
 
         if self.planned_submission_end.data:
             self.planned_submission_end.data = pytz.UTC.localize(

--- a/purchasing/templates/conductor/detail/_post_opportunities.html
+++ b/purchasing/templates/conductor/detail/_post_opportunities.html
@@ -9,6 +9,13 @@
 
       <h4>Post opportunity to Beacon</h4>
 
+      {% if form.errors.keys()|length > 0 %}
+      <div class="alert alert-danger alert-dismissible flashed-alert fade in" role="alert">
+        <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+        <i class="fa fa-exclamation-triangle"></i> There were problems submitting your opportunity! Please check below and correct them.
+      </div>
+      {% endif %}
+
       <div class="form-group">
         <label for="department" class="control-label">Department <span class="form-required">*</span></label>
         <p class="help-block">Who is the using department for this opportunity?</p>

--- a/purchasing/templates/opportunities/admin/opportunity.html
+++ b/purchasing/templates/opportunities/admin/opportunity.html
@@ -8,9 +8,15 @@
       <form method="POST" enctype="multipart/form-data" action="{% if opportunity.id %}{{ url_for('opportunities_admin.edit', opportunity_id=opportunity.id) }}{% else %}{{ url_for('opportunities_admin.new') }}{% endif %}" id="js-opportunity-form">
 
         {{ form.csrf_token() }}
+
         {% include "includes/flashes.html" %}
 
-         <div class="spacer-20"></div>
+        {% if form.errors.keys()|length > 0 %}
+        <div class="alert alert-danger alert-dismissible flashed-alert fade in" role="alert">
+          <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+          <i class="fa fa-exclamation-triangle"></i> There were problems submitting your opportunity! Please check below and correct them.
+        </div>
+        {% endif %}
 
         <h4>Post an Opportunity</h4>
         <h3>Fill out this form, and OMB will publish your opportunity to the City of Pittsburgh's new Opportunities website.</h3>

--- a/purchasing/utils.py
+++ b/purchasing/utils.py
@@ -196,7 +196,7 @@ class RequiredIf(InputRequired):
             )
         if bool(other_field.data) and not bool(field.data):
             raise StopValidation(
-                'You must also fill out "%s" if you want to fill this out.' %
+                'You filled out "%s" but left this blank -- please fill this out as well.' %
                 other_field.label.text if other_field.label else self.other_field_name
             )
 

--- a/purchasing_test/integration/conductor/test_conductor.py
+++ b/purchasing_test/integration/conductor/test_conductor.py
@@ -29,7 +29,7 @@ class TestConductorSetup(BaseTestCase):
     def setUp(self):
         super(TestConductorSetup, self).setUp()
         # create a conductor and general staff person
-        self.county_type = ContractTypeFactory.create(**{'name': 'County'})
+        self.county_type = ContractTypeFactory.create(**{'name': 'County', 'allow_opportunities': True})
         self.department = DepartmentFactory.create(**{'name': 'test department'})
 
         self.conductor_role_id = insert_a_role('conductor')
@@ -535,7 +535,8 @@ class TestConductor(TestConductorSetup):
             'planned_submission_start': datetime.date.today() + datetime.timedelta(2),
             'planned_submission_end': datetime.datetime.today() + datetime.timedelta(days=2),
             'department': self.department.id,
-            'subcategories-{}'.format(self.category.id): 'on'
+            'subcategories-{}'.format(self.category.id): 'on',
+            'opportunity_type': self.county_type.id
         })
 
         self.assertEquals(Opportunity.query.count(), 1)

--- a/purchasing_test/integration/opportunities/test_opportunity_admin.py
+++ b/purchasing_test/integration/opportunities/test_opportunity_admin.py
@@ -22,7 +22,8 @@ from purchasing.data.importer.nigp import main as import_nigp
 
 from purchasing_test.test_base import BaseTestCase
 from purchasing_test.factories import (
-    OpportunityDocumentFactory, VendorFactory, DepartmentFactory, CategoryFactory
+    OpportunityDocumentFactory, VendorFactory, DepartmentFactory, CategoryFactory,
+    ContractTypeFactory
 )
 from purchasing_test.util import (
     insert_a_role, insert_a_user, insert_a_document,
@@ -44,6 +45,7 @@ class TestOpportunitiesAdminBase(BaseTestCase):
         self.admin_role = insert_a_role('admin')
         self.staff_role = insert_a_role('staff')
         self.department1 = DepartmentFactory(name='test')
+        self.opportunity_type = ContractTypeFactory.create(allow_opportunities=True)
 
         self.admin = insert_a_user(email='foo@foo.com', role=self.admin_role)
         self.staff = insert_a_user(email='foo2@foo.com', role=self.staff_role)
@@ -116,7 +118,8 @@ class TestOpportunitiesAdmin(TestOpportunitiesAdminBase):
             'planned_submission_start': datetime.date.today(),
             'planned_submission_end': datetime.date.today() + datetime.timedelta(1),
             'is_public': False, 'subcategories-1': 'on', 'subcategories-2': 'on',
-            'subcategories-3': 'on', 'subcategories-4': 'on'
+            'subcategories-3': 'on', 'subcategories-4': 'on',
+            'opportunity_type': self.opportunity_type.id
         }
 
         self.client.post('/beacon/admin/opportunities/new', data=data)
@@ -157,7 +160,8 @@ class TestOpportunitiesAdmin(TestOpportunitiesAdminBase):
             'planned_publish': datetime.date.today(),
             'planned_submission_start': datetime.date.today(),
             'planned_submission_end': datetime.date.today() + datetime.timedelta(1),
-            'is_public': False, 'subcategories-{}'.format(Category.query.first().id): 'on'
+            'is_public': False, 'subcategories-{}'.format(Category.query.first().id): 'on',
+            'opportunity_type': self.opportunity_type.id
         }
 
         # assert that we create a new user when we build with a new email
@@ -182,7 +186,8 @@ class TestOpportunitiesAdmin(TestOpportunitiesAdminBase):
             'planned_publish': datetime.date.today(),
             'planned_submission_start': datetime.date.today(),
             'planned_submission_end': datetime.date.today() + datetime.timedelta(1),
-            'save_type': 'save', 'subcategories-{}'.format(Category.query.first().id): 'on'
+            'save_type': 'save', 'subcategories-{}'.format(Category.query.first().id): 'on',
+            'opportunity_type': self.opportunity_type.id
         }
 
         # assert that you need a title & description
@@ -242,7 +247,8 @@ class TestOpportunitiesAdmin(TestOpportunitiesAdminBase):
             'planned_submission_start': datetime.date.today(), 'title': 'Updated',
             'is_public': True, 'description': 'Updated Contract!', 'save_type': 'public',
             'contact_email': self.admin.email, 'department': self.department1.id,
-            'subcategories-{}'.format(Category.query.all()[-1].id): 'on'
+            'subcategories-{}'.format(Category.query.all()[-1].id): 'on',
+            'opportunity_type': self.opportunity_type.id
         })
 
         self.assert200(self.client.get('/beacon/opportunities'))
@@ -503,7 +509,8 @@ class TestOpportunitiesPublic(TestOpportunitiesAdminBase):
                 'planned_publish': datetime.date.today(),
                 'planned_submission_start': datetime.date.today(),
                 'planned_submission_end': datetime.date.today() + datetime.timedelta(1),
-                'save_type': 'publish', 'subcategories-{}'.format(Category.query.all()[-1].id): 'on'
+                'save_type': 'publish', 'subcategories-{}'.format(Category.query.all()[-1].id): 'on',
+                'opportunity_type': self.opportunity_type.id
             })
 
             self.assertEquals(Opportunity.query.count(), 5)
@@ -522,7 +529,8 @@ class TestOpportunitiesPublic(TestOpportunitiesAdminBase):
             'planned_publish': datetime.date.today(),
             'planned_submission_start': datetime.date.today(),
             'planned_submission_end': datetime.date.today() + datetime.timedelta(1),
-            'save_type': 'save', 'subcategories-{}'.format(Category.query.all()[-1].id): 'on'
+            'save_type': 'save', 'subcategories-{}'.format(Category.query.all()[-1].id): 'on',
+            'opportunity_type': self.opportunity_type.id
         }
 
         self.login_user(self.admin)


### PR DESCRIPTION
### What Changed
- Added a notification to the top of a Beacon form telling people if there were problems with filling out the form.
- Made Department & Contract Type actually required fields
- Improved some of the validation messaging.
### Issues
- fixes #450
- starts work on #285 but that still needs some serious js and/or re-thinking
### Screenshot

![](https://cloud.githubusercontent.com/assets/1957344/10151878/23644832-6601-11e5-8df8-9b3939842202.png)
