### PR TITLE
Vendor download comma fix

### DIFF
--- a/purchasing/conductor/metrics/views.py
+++ b/purchasing/conductor/metrics/views.py
@@ -18,7 +18,7 @@ def index():
 
 @blueprint.route('/download/<int:flow_id>')
 @requires_roles('conductor', 'admin', 'superadmin')
-def download_csv_flow(flow_id):
+def download_tsv_flow(flow_id):
     flow = Flow.query.get(flow_id)
 
     stages = db.session.execute(
@@ -54,19 +54,19 @@ def download_csv_flow(flow_id):
         }
     ).fetchall()
 
-    csv, headers = reshape_metrics_granular(stages)
+    tsv, headers = reshape_metrics_granular(stages)
 
     def stream():
-        yield ','.join(headers) + '\n'
-        for contract_id, values in csv.iteritems():
-            yield ','.join([str(i) for i in values]) + '\n'
+        yield '\t'.join(headers) + '\n'
+        for contract_id, values in tsv.iteritems():
+            yield '\t'.join([str(i) for i in values]) + '\n'
 
     resp = Response(
         stream_with_context(stream()),
         headers={
-            "Content-Disposition": "attachment; filename=conductor-{}-metrics.csv".format(flow.flow_name)
+            "Content-Disposition": "attachment; filename=conductor-{}-metrics.tsv".format(flow.flow_name)
         },
-        mimetype='text/csv'
+        mimetype='text/tsv'
     )
 
     return resp

--- a/purchasing/opportunities/admin/views.py
+++ b/purchasing/opportunities/admin/views.py
@@ -171,23 +171,23 @@ def signups():
     '''
     def stream():
         # yield the title columns
-        yield 'first_name,last_name,business_name,email,phone_number,' +\
-            'minority_owned,woman_owned,veteran_owned,' +\
-            'disadvantaged_owned,categories,opportunities\n'
+        yield 'first_name\tlast_name\tbusiness_name\temail\tphone_number\t' +\
+            'minority_owned\twoman_owned\tveteran_owned\t' +\
+            'disadvantaged_owned\tcategories\topportunities\n'
 
         vendors = Vendor.query.all()
         for vendor in vendors:
             row = vendor.build_downloadable_row()
-            yield ','.join([str(i) for i in row]) + '\n'
+            yield '\t'.join([str(i) for i in row]) + '\n'
 
     current_app.logger.info('BEACON VENDOR CSV DOWNLOAD')
 
     resp = Response(
         stream_with_context(stream()),
         headers={
-            "Content-Disposition": "attachment; filename=vendors-{}.csv".format(datetime.date.today())
+            "Content-Disposition": "attachment; filename=vendors-{}.tsv".format(datetime.date.today())
         },
-        mimetype='text/csv'
+        mimetype='text/tsv'
     )
 
     return resp

--- a/purchasing/templates/conductor/metrics/index.html
+++ b/purchasing/templates/conductor/metrics/index.html
@@ -9,7 +9,7 @@
   <h3>Choose a flow to download metrics:</h3>
   <ul>
     {% for flow in flows %}
-    <li><a href="{{ url_for('conductor_metrics.download_csv_flow', flow_id=flow.id) }}">{{ flow.flow_name }}</a></li>
+    <li><a href="{{ url_for('conductor_metrics.download_tsv_flow', flow_id=flow.id) }}">{{ flow.flow_name }}</a></li>
     {% endfor %}
   </ul>
 

--- a/purchasing_test/integration/conductor/test_conductor_metrics.py
+++ b/purchasing_test/integration/conductor/test_conductor_metrics.py
@@ -11,7 +11,7 @@ class TestConductorMetrics(TestConductorSetup):
         self.logout_user()
         self.assertEquals(self.client.get('/conductor/metrics/').status_code, 302)
 
-    def test_metrics_csv_download(self):
+    def test_metrics_tsv_download(self):
         self.assign_contract()
         transition_url_1 = self.build_detail_view(self.contract1) + '/transition'
 
@@ -24,16 +24,16 @@ class TestConductorMetrics(TestConductorSetup):
             self.client.get(transition_url_2)
 
         request = self.client.get('/conductor/metrics/download/{}'.format(self.flow.id), follow_redirects=True)
-        self.assertEquals(request.mimetype, 'text/csv')
+        self.assertEquals(request.mimetype, 'text/tsv')
         self.assertEquals(
             request.headers.get('Content-Disposition'),
-            'attachment; filename=conductor-{}-metrics.csv'.format(self.flow.flow_name)
+            'attachment; filename=conductor-{}-metrics.tsv'.format(self.flow.flow_name)
         )
 
-        csv_data = request.data.split('\n')[:-1]
+        tsv_data = request.data.split('\n')[:-1]
 
         # we should have two rows plus the header
-        self.assertEquals(len(csv_data), 3)
-        for row in csv_data[1:]:
+        self.assertEquals(len(tsv_data), 3)
+        for row in tsv_data[1:]:
             # there should be four metadata columns plus the number of stages
-            self.assertEquals(len(row.split(',')), len(self.flow.stage_order) + 4)
+            self.assertEquals(len(row.split('\t')), len(self.flow.stage_order) + 4)

--- a/purchasing_test/integration/opportunities/test_opportunity_admin.py
+++ b/purchasing_test/integration/opportunities/test_opportunity_admin.py
@@ -359,20 +359,20 @@ class TestOpportunitiesAdmin(TestOpportunitiesAdminBase):
 
         self.login_user(self.staff)
         request = self.client.get('/beacon/admin/signups')
-        self.assertEquals(request.mimetype, 'text/csv')
+        self.assertEquals(request.mimetype, 'text/tsv')
         self.assertEquals(
             request.headers.get('Content-Disposition'),
-            'attachment; filename=vendors-{}.csv'.format(datetime.date.today())
+            'attachment; filename=vendors-{}.tsv'.format(datetime.date.today())
         )
 
         # python adds an extra return character to the end,
         # so we chop it off. we should have the header row and
         # the two rows we inserted above
-        csv_data = request.data.split('\n')[:-1]
+        tsv_data = request.data.split('\n')[:-1]
 
-        self.assertEquals(len(csv_data), 3)
-        for row in csv_data:
-            self.assertEquals(len(row.split(',')), 11)
+        self.assertEquals(len(tsv_data), 3)
+        for row in tsv_data:
+            self.assertEquals(len(row.split('\t')), 11)
 
 class TestOpportunitiesPublic(TestOpportunitiesAdminBase):
     def setUp(self):


### PR DESCRIPTION
### What changed
- adds tabs to header of vendor signup download
- joins signup responses by tab
### What's needed
- Open question: should we be spitting out tsv's here? 
### Screencap

<img width="972" alt="screen shot 2015-10-06 at 3 40 18 pm" src="https://cloud.githubusercontent.com/assets/3640800/10324715/9dd64e68-6c40-11e5-9936-bca0fea44cba.png">
### Issues
- #465 
