### PR TITLE
add item number for in-progress contracts

### DIFF
--- a/purchasing/conductor/manager/views.py
+++ b/purchasing/conductor/manager/views.py
@@ -41,6 +41,7 @@ from purchasing.conductor.manager import blueprint
 def index():
     in_progress = db.session.query(
         db.distinct(ContractBase.id).label('id'),
+        ContractBase,
         ContractBase.description, Flow.flow_name,
         Stage.name.label('stage_name'), ContractStage.entered,
         User.first_name, User.email,
@@ -55,6 +56,8 @@ def index():
         Stage, Stage.id == ContractBase.current_stage_id
     ).join(
         Flow, Flow.id == ContractBase.flow_id
+    ).outerjoin(
+        ContractProperty, ContractProperty.contract_id == ContractBase.id
     ).join(User, User.id == ContractBase.assigned_to).filter(
         ContractStage.flow_id == ContractBase.flow_id,
         ContractStage.entered != None,

--- a/purchasing/static/js/conductor/index.js
+++ b/purchasing/static/js/conductor/index.js
@@ -36,9 +36,10 @@ $(document).ready(function() {
     progressTable.draw();
   });
 
-  function format(description, department, controller) {
+  function format(itemNumber, description, department, controller) {
     return '<table class="table table-condensed">' +
       '<tbody>' +
+        '<tr><td class="dropdown-table-border-right"><strong>Item #</strong></td><td>' + itemNumber + '</td></tr>' +
         '<tr><td class="dropdown-table-border-right"><strong>Full Description</strong></td><td>' + description + '</td></tr>' +
         '<tr><td class="dropdown-table-border-right"><strong>Department</strong></td><td>' + department + '</td></tr>' +
         '<tr><td class="dropdown-table-border-right"><strong>Controller #</strong></td><td>' + controller + '</td></tr>' +
@@ -57,7 +58,10 @@ $(document).ready(function() {
       tr.removeClass('shown');
       clicked.find('.fa').removeClass('fa-minus').addClass('fa-plus');
     } else {
-      row.child( format( tr.attr('data-full-description'), tr.attr('data-department'), tr.attr('data-controller') ) ).show();
+      row.child(format(
+        tr.attr('data-item-number'), tr.attr('data-full-description'),
+        tr.attr('data-department'), tr.attr('data-controller')
+      )).show();
       tr.addClass('shown');
       clicked.find('.fa').removeClass('fa-plus').addClass('fa-minus');
     }

--- a/purchasing/templates/conductor/table/in_progress.html
+++ b/purchasing/templates/conductor/table/in_progress.html
@@ -1,7 +1,7 @@
 <table class="display" id="js-table-progress">
   <thead>
     <th></th>
-    <th>Item #</th>
+    <th>Spec #</th>
     <th>Name</th>
     <th>Current Step</th>
     <th>Current Step Started Sort (Hidden)</th>
@@ -17,10 +17,21 @@
     {%- elif days_from_today(contract.entered) < -7 -%}contract-row-expiring-warning
     {%- endif -%}" data-department="{{ contract.department }}"
     data-controller="{{ contract.financial_id or 'Not set' }}"
-    data-full-description="{{ contract.description|title }}">
+    data-full-description="{{ contract.description|title }}"
+    data-item-number="{{ contract.id }}">
 
       <td class="details-control"><i class="fa fa-plus"></i></td>
-      <td>{{ contract.id }}</td>
+
+      <td>
+        {% if contract[1].get_spec_number().value %}
+        {{ contract[1].get_spec_number().value }}
+        {% elif contract[1].get_spec_number().value %}
+        {{ contract[1].parent }}
+        {% else %}
+        {{ contract.id }} <br>
+        <span class="text-muted"><small>No spec number, <br>displaying item #</small></span>
+        {% endif %}
+      </td>
 
       <td>
         <span {% if contract.stage_name -%}class="title-update-span"{%- endif -%}>{{ contract.description|title|truncate(40) }}</span>


### PR DESCRIPTION
### What Changed
- move item number to the dropdown
- if there is no spec number, attempt to use the parent spec number. if there is no parent, use the item number and note that there is no spec number (this should only be true for new contracts)
### Issues
- fixes #416 
### Screenshot

![screen shot 2015-10-07 at 2 36 07 pm](https://cloud.githubusercontent.com/assets/1957344/10370956/c7e3787c-6da6-11e5-9a2c-2a2b91792678.png)

(I did this on the plane which is why it looks a bit weird -- no google fonts)
