### PR TITLE
Beacon encode fix

### DIFF
--- a/purchasing/opportunities/admin/views.py
+++ b/purchasing/opportunities/admin/views.py
@@ -132,7 +132,7 @@ def publish(opportunity_id):
 
         current_app.logger.info(
 '''BEACON APPROVED: ID: {} | Title: {} | Publish Date: {} | Submission Start Date: {} | Submission End Date: {} '''.format(
-                opportunity.id, opportunity.description, str(opportunity.planned_publish),
+                opportunity.id, opportunity.title.encode('ascii', 'ignore'), str(opportunity.planned_publish),
                 str(opportunity.planned_submission_start), str(opportunity.planned_submission_end)
             )
         )

--- a/purchasing/opportunities/front/views.py
+++ b/purchasing/opportunities/front/views.py
@@ -330,7 +330,7 @@ def detail(opportunity_id):
                 return redirect(url_for('opportunities.detail', opportunity_id=opportunity.id))
 
         current_app.logger.info('BEACON FRONT OPPORTUNITY DETAIL VIEW | Opportunity {} (ID: {})'.format(
-            opportunity.description, opportunity.id
+            opportunity.description.encode('ascii', 'ignore'), opportunity.id
         ))
 
         return render_template(

--- a/purchasing/opportunities/models.py
+++ b/purchasing/opportunities/models.py
@@ -237,7 +237,7 @@ class Opportunity(Model):
 '''BEACON NEW - New Opportunity Created: Department: {} | Title: {} | Publish Date: {} | Submission Start Date: {} | Submission End Date: {}
             '''.format(
                 opportunity.id, opportunity.department.name if opportunity.department else '',
-                opportunity.description.encode('ascii', 'ignore'),
+                opportunity.title.encode('ascii', 'ignore'),
                 str(opportunity.planned_publish),
                 str(opportunity.planned_submission_start), str(opportunity.planned_submission_end)
             )
@@ -265,7 +265,7 @@ class Opportunity(Model):
         current_app.logger.info(
 '''BEACON Update - Opportunity Updated: ID: {} | Title: {} | Publish Date: {} | Submission Start Date: {} | Submission End Date: {}
             '''.format(
-                self.id, self.description, str(self.planned_publish),
+                self.id, self.title.encode('ascii', 'ignore'), str(self.planned_publish),
                 str(self.planned_submission_start), str(self.planned_submission_end)
             )
         )
@@ -295,7 +295,7 @@ class Opportunity(Model):
             current_app.logger.info(
 '''BEACON PUBLISHED:  ID: {} | Title: {} | Publish Date: {} | Submission Start Date: {} | Submission End Date: {}
                 '''.format(
-                    self.id, self.description, str(self.planned_publish),
+                    self.id, self.title.encode('ascii', 'ignore'), str(self.planned_publish),
                     str(self.planned_submission_start), str(self.planned_submission_end)
                 )
             )

--- a/purchasing_test/integration/opportunities/test_opportunities_base.py
+++ b/purchasing_test/integration/opportunities/test_opportunities_base.py
@@ -48,6 +48,7 @@ class TestOpportunitiesAdminBase(BaseTestCase):
 
         self.opportunity1 = insert_an_opportunity(
             contact=self.admin, created_by=self.staff,
+            title='tést unïcode title', description='tést unïcode déscription',
             is_public=True, planned_publish=datetime.date.today() + datetime.timedelta(1),
             planned_submission_start=datetime.date.today() + datetime.timedelta(2),
             planned_submission_end=datetime.datetime.today() + datetime.timedelta(2),


### PR DESCRIPTION
### What changed
- changed logger text to use title instead of description for beacon opportunities
- added unicode encoding support
### What's needed
- tests for this
### Screenshot

<img width="1172" alt="screen shot 2015-10-19 at 3 44 23 pm" src="https://cloud.githubusercontent.com/assets/3640800/10593398/4c9579ce-7678-11e5-9e51-5042ff0cc0cc.png">
