### PR TITLE
allow for reversion backdating, fixes #543

### DIFF
--- a/purchasing/app.py
+++ b/purchasing/app.py
@@ -9,8 +9,6 @@ import datetime
 from pkgutil import iter_modules
 from importlib import import_module
 
-import pytz
-
 from werkzeug.utils import import_string
 
 from flask import Flask, render_template, Blueprint
@@ -27,7 +25,7 @@ from purchasing.users.models import AnonymousUser
 from purchasing.filters import (
     url_for_other_page, thispage, format_currency, better_title,
     days_from_today, datetimeformat, format_days_from_today,
-    newline_to_br, localize
+    newline_to_br, localize, now
 )
 
 # import models so that flask-migrate can auto-detect
@@ -123,10 +121,10 @@ def register_jinja_extensions(app):
     app.jinja_env.globals['url_for_other_page'] = url_for_other_page
     app.jinja_env.globals['thispage'] = thispage
     app.jinja_env.globals['_current_user'] = current_user
-    app.jinja_env.globals['_now'] = pytz.UTC.localize(datetime.datetime.utcnow()).astimezone(app.config['DISPLAY_TIMEZONE'])
     app.jinja_env.globals['today'] = datetime.date.today()
     app.jinja_env.globals['days_from_today'] = days_from_today
     app.jinja_env.globals['format_days_from_today'] = format_days_from_today
+    app.jinja_env.globals['_now'] = now
     app.jinja_env.filters['currency'] = format_currency
     app.jinja_env.filters['title'] = better_title
     app.jinja_env.filters['datetimeformat'] = datetimeformat

--- a/purchasing/conductor/manager/views.py
+++ b/purchasing/conductor/manager/views.py
@@ -225,7 +225,8 @@ def detail(contract_id, stage_id=-1):
 def transition(contract_id, stage_id):
 
     contract = ContractBase.query.get(contract_id)
-    complete_form = CompleteForm(started=contract.get_current_stage().entered)
+    stage = ContractStage.query.filter(ContractStage.id == stage_id).first()
+    complete_form = CompleteForm(started=stage.entered)
 
     if (request.method == 'POST' and complete_form.validate_on_submit()) or (request.method == 'GET'):
         if request.method == 'POST':

--- a/purchasing/filters.py
+++ b/purchasing/filters.py
@@ -55,6 +55,9 @@ def _current_user():
     args['_current_user'] = current_user
     return url_for(request.endpoint, **args)
 
+def now():
+    return pytz.UTC.localize(datetime.datetime.utcnow()).astimezone(current_app.config['DISPLAY_TIMEZONE'])
+
 def better_title(string):
     '''drop in replacement for jinja default title filter
 

--- a/purchasing/static/less/conductor/_detail_view.less
+++ b/purchasing/static/less/conductor/_detail_view.less
@@ -37,3 +37,15 @@ form {
   text-transform: uppercase;
   font-weight: 700;
 }
+
+.form-group-small-stack {
+  margin-bottom: 3px;
+}
+
+.alert-small {
+  padding: 8px;
+}
+
+.stage-title {
+  margin-top: 10px;
+}

--- a/purchasing/templates/conductor/detail/current_stage_title.html
+++ b/purchasing/templates/conductor/detail/current_stage_title.html
@@ -2,17 +2,44 @@
 
 <div class="row">
   {% if active_stage.id != current_stage.id %}
-  <div class="col-md-9">
-    <span class="text-bigger"><strong>{{ current_stage.name }}</strong></span> <br/>
+
+  <div class="col-md-7">
+    <span class="text-bigger"><strong>{{ active_stage.name }}</strong></span> <br/>
     <span>
       This stage has been completed. <a href="{{ url_for('conductor.detail', contract_id=contract.id, stage_id=current_stage.id) }}">View current stage</a>
     </span>
   </div>
-  <div class="col-md-3 pull-right">
-    <a href="{{ url_for('conductor.transition', contract_id=contract.id, stage_id=active_stage.id, destination=active_stage.stage_id) }}" class="btn btn-detail btn-primary">Revert to this stage</a></span>
+
+  <div class="col-md-5">
+    <form class="form-inline pull-right" method="POST" action="{{ url_for('conductor.transition', contract_id=contract.id, stage_id=active_stage.id, destination=active_stage.stage_id) }}">
+      {{ complete_form.csrf_token() }}
+
+      {% if complete_form.errors['complete'] %}
+      <div class="alert alert-danger alert-dismissable">
+        <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+        {{ complete_form.errors['complete'] }}
+      </div>
+      {% endif %}
+
+      <div class="alert alert-danger alert-dismissable hidden js-datepicker-validator">
+        This date creates conflicts.
+      </div>
+
+      {{ macros.with_errors(complete_form.complete, **{
+        'class': 'datetimepicker form-control',
+        'data-started': active_stage.entered|localize,
+        'data-maximum': _now()
+      } )}}
+
+      <button type="submit" class="btn btn-default js-transition">Revert</button>
+
+    </form>
   </div>
+
   <div class="spacer-10"></div>
+
   {% else %}
+
   <div class="col-md-7">
     <span class="text-bigger btn-share-row">Current stage: <strong>{{ current_stage.name }}</strong></span>
   </div>
@@ -34,8 +61,9 @@
       {{ macros.with_errors(complete_form.complete, **{
         'class': 'datetimepicker form-control',
         'data-started': active_stage.entered|localize,
-        'data-maximum': _now
+        'data-maximum': _now()
       } )}}
+
 
       <button type="submit" class="btn btn-success js-transition">Save</button>
 

--- a/purchasing/templates/conductor/detail/current_stage_title.html
+++ b/purchasing/templates/conductor/detail/current_stage_title.html
@@ -4,34 +4,38 @@
   {% if active_stage.id != current_stage.id %}
 
   <div class="col-md-7">
-    <span class="text-bigger"><strong>{{ active_stage.name }}</strong></span> <br/>
-    <span>
-      This stage has been completed. <a href="{{ url_for('conductor.detail', contract_id=contract.id, stage_id=current_stage.id) }}">View current stage</a>
+    <h3 class="stage-title"><strong>{{ active_stage.name }}</strong></h3>
+    <span class="text-muted">
+      This stage has been completed. <a href="{{ url_for('conductor.detail', contract_id=contract.id, stage_id=current_stage.id) }}">View current stage</a>.
     </span>
   </div>
 
   <div class="col-md-5">
-    <form class="form-inline pull-right" method="POST" action="{{ url_for('conductor.transition', contract_id=contract.id, stage_id=active_stage.id, destination=active_stage.stage_id) }}">
+    <form class="form pull-right" method="POST" action="{{ url_for('conductor.transition', contract_id=contract.id, stage_id=active_stage.id, destination=active_stage.stage_id) }}">
       {{ complete_form.csrf_token() }}
 
       {% if complete_form.errors['complete'] %}
-      <div class="alert alert-danger alert-dismissable">
+      <div class="alert alert-small form-group-small-stack alert-danger alert-dismissable">
         <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
         {{ complete_form.errors['complete'] }}
       </div>
       {% endif %}
 
-      <div class="alert alert-danger alert-dismissable hidden js-datepicker-validator">
+      <div class="alert alert-small form-group-small-stack alert-danger alert-dismissable hidden js-datepicker-validator">
         This date creates conflicts.
       </div>
 
-      {{ macros.with_errors(complete_form.complete, **{
-        'class': 'datetimepicker form-control',
-        'data-started': active_stage.entered|localize,
-        'data-maximum': _now()
-      } )}}
+      <div class="form-group form-group-small-stack">
+        {{ macros.with_errors(complete_form.complete, **{
+          'class': 'datetimepicker form-control',
+          'data-started': active_stage.entered|localize,
+          'data-maximum': _now()
+        } )}}
+      </div>
 
-      <button type="submit" class="btn btn-default js-transition">Revert</button>
+      <div class="form-group form-group-small-stack">
+        <button type="submit" class="btn btn-default js-transition form-control">Revert</button>
+      </div>
 
     </form>
   </div>
@@ -41,31 +45,37 @@
   {% else %}
 
   <div class="col-md-7">
-    <span class="text-bigger btn-share-row">Current stage: <strong>{{ current_stage.name }}</strong></span>
+    <h3 class="stage-title"><strong>{{ current_stage.name }}</strong></h3>
+    <span class="text-muted">
+      Current stage.
+    </span>
   </div>
   <div class="col-md-5">
-    <form class="form-inline pull-right" method="POST" action="{{ url_for('conductor.transition', contract_id=contract.id, stage_id=active_stage.id) }}">
+    <form class="form pull-right" method="POST" action="{{ url_for('conductor.transition', contract_id=contract.id, stage_id=active_stage.id) }}">
       {{ complete_form.csrf_token() }}
 
       {% if complete_form.errors['complete'] %}
-      <div class="alert alert-danger alert-dismissable">
+      <div class="alert alert-small form-group-small-stack alert-danger alert-dismissable">
         <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
         {{ complete_form.errors['complete'] }}
       </div>
       {% endif %}
 
-      <div class="alert alert-danger alert-dismissable hidden js-datepicker-validator">
+      <div class="alert alert-small form-group-small-stack alert-danger alert-dismissable hidden js-datepicker-validator">
         This date creates conflicts.
       </div>
 
-      {{ macros.with_errors(complete_form.complete, **{
-        'class': 'datetimepicker form-control',
-        'data-started': active_stage.entered|localize,
-        'data-maximum': _now()
-      } )}}
+      <div class="form-group form-group-small-stack">
+        {{ macros.with_errors(complete_form.complete, **{
+          'class': 'datetimepicker form-control',
+          'data-started': active_stage.entered|localize,
+          'data-maximum': _now()
+        } )}}
+      </div>
 
-
-      <button type="submit" class="btn btn-success js-transition">Save</button>
+      <div class="form-group form-group-small-stack">
+        <button type="submit" class="btn btn-success js-transition form-control">Mark complete</button>
+      </div>
 
     </form>
   </div>

--- a/purchasing/templates/macros/render_activity_log.html
+++ b/purchasing/templates/macros/render_activity_log.html
@@ -35,19 +35,19 @@
   {%- elif action.action_type == 'entered' -%}
   <div class="action-event action-event-date js-filter-action-stage">
     <span class="event-icon"><i class="fa fa-circle-o"></i></span>
-    {{ pn.print_name(action, current_user) }} started work on "<strong>{{ action.action_detail.stage_name }}</strong>" on {{ action.action_detail.timestamp|datetimeformat('%m/%d/%y') }}.
+    {{ pn.print_name(action, current_user) }} started work on "<strong>{{ action.action_detail.stage_name }}</strong>" on {{ action.action_detail.timestamp|datetimeformat('%m/%d/%y') }} (marked complete on {{ action.taken_at|datetimeformat('%m/%d/%y') }}).
   </div>
 
   {%- elif action.action_type == 'exited' and action.action_detail -%}
   <div class="action-event action-event-date js-filter-action-stage">
     <span class="event-icon"><i class="fa fa-check-circle"></i></span>
-    {{ pn.print_name(action, current_user) }} completed work on "<strong>{{ action.action_detail.stage_name }}</strong>" on {{ action.action_detail.timestamp|datetimeformat('%m/%d/%y') }}.
+    {{ pn.print_name(action, current_user) }} completed work on "<strong>{{ action.action_detail.stage_name }}</strong>" on {{ action.action_detail.timestamp|datetimeformat('%m/%d/%y') }} (marked complete on {{ action.taken_at|datetimeformat('%m/%d/%y') }}).
   </div>
 
   {%- elif action.action_type == 'reversion' -%}
   <div class="action-event action-event-date js-filter-action-stage">
     <span class="event-icon"><i class="fa fa-repeat"></i></span>
-    {{ action.action_detail.label }} on "<strong>{{ action.action_detail.stage_name }}</strong>" on {{ action.action_detail.timestamp|datetimeformat('%m/%d/%y') }}.
+    {{ action.action_detail.label }} on "<strong>{{ action.action_detail.stage_name }}</strong>" on {{ action.action_detail.timestamp|datetimeformat('%m/%d/%y') }} (marked complete on {{ action.taken_at|datetimeformat('%m/%d/%y') }}).
   </div>
 
   {# metadata update handling #}

--- a/purchasing_test/integration/conductor/test_conductor.py
+++ b/purchasing_test/integration/conductor/test_conductor.py
@@ -337,7 +337,7 @@ class TestConductor(TestConductorSetup):
         '''Test that we can access completed stages but not non-started ones
         '''
         assign = self.assign_contract()
-        self.client.get(self.detail_view.format(assign.id, self.stage1.id) + '/transition')
+        self.client.get(self.detail_view.format(assign.id, assign.get_current_stage().id) + '/transition')
 
         # assert the current stage is stage 2
         redir = self.client.get('/conductor/contract/{}'.format(assign.id))
@@ -354,7 +354,7 @@ class TestConductor(TestConductorSetup):
         '''Test flow switching back and forth in conductor
         '''
         assign = self.assign_contract()
-        self.client.get(self.detail_view.format(assign.id, self.stage1.id) + '/transition')
+        self.client.get(self.detail_view.format(assign.id, assign.get_current_stage().id) + '/transition')
         # we should have three actions -- entered, exited, entered
         self.assertEquals(ContractStageActionItem.query.count(), 3)
 


### PR DESCRIPTION
### What Changed
- Addresses issues where the min_date would be behind the max date because the jinja `now` global was not resetting
- Allows essentially for full time control of both stopping and starting of stages through reversions and back-dating.
### Issues
- Fixes #543 
### Screencap

![autom8](https://cloud.githubusercontent.com/assets/1957344/10703986/8b48020a-7988-11e5-9718-2b28f596be57.gif)

cc @dormansteph 
