### PR TITLE
modifications to conductor -> beacon flow

### DIFF
--- a/purchasing/conductor/forms.py
+++ b/purchasing/conductor/forms.py
@@ -21,8 +21,9 @@ from purchasing.filters import better_title
 from purchasing.users.models import Department, User
 from purchasing.data.flows import Flow
 from purchasing.data.companies import get_all_companies_query
+from purchasing.data.contracts import ContractType
 
-from purchasing.opportunities.forms import OpportunityForm
+from purchasing.opportunities.forms import OpportunityForm, city_domain_email
 from purchasing.utils import RequiredIf, RequiredOne, RequiredNotBoth
 
 EMAIL_REGEX = re.compile(r'^.+@([^.@][^@]+)$', re.IGNORECASE)
@@ -136,7 +137,7 @@ class SendUpdateForm(Form):
     attachments = FieldList(FormField(AttachmentForm), min_entries=1)
 
 class PostOpportunityForm(OpportunityForm):
-    pass
+    contact_email = TextField(validators=[Email(), city_domain_email, Optional()])
 
 class NoteForm(Form):
     '''Adds a note to the contract stage view

--- a/purchasing/conductor/manager/views.py
+++ b/purchasing/conductor/manager/views.py
@@ -32,8 +32,9 @@ from purchasing.conductor.forms import (
 )
 
 from purchasing.conductor.util import (
-    handle_form, ContractMetadataObj, build_subscribers,
-    json_serial, parse_companies, UpdateFormObj, assign_a_contract
+    ContractMetadataObj, UpdateFormObj, ConductorObj,
+    handle_form, build_subscribers, json_serial,
+    parse_companies, assign_a_contract,
 )
 
 from purchasing.conductor.manager import blueprint
@@ -162,7 +163,7 @@ def detail(contract_id, stage_id=-1):
     note_form = NoteForm()
     update_form = SendUpdateForm(obj=UpdateFormObj(current_stage))
     opportunity_form = PostOpportunityForm(
-        obj=contract.opportunity if contract.opportunity else contract
+        obj=contract.opportunity if contract.opportunity else ConductorObj(contract)
     )
     metadata_form = ContractMetadataForm(obj=ContractMetadataObj(contract))
     complete_form = CompleteForm()

--- a/purchasing/conductor/util.py
+++ b/purchasing/conductor/util.py
@@ -4,11 +4,12 @@ import datetime
 
 from sqlalchemy.exc import IntegrityError
 
-from flask import request, current_app
+from flask import current_app
 from flask_login import current_user
 
 from purchasing.database import db
 from purchasing.notifications import Notification
+from purchasing.filters import better_title
 
 from purchasing.data.contracts import ContractBase, ContractType
 from purchasing.data.contract_stages import ContractStageActionItem
@@ -37,7 +38,7 @@ class UpdateFormObj(object):
 
 class ConductorObj(object):
     def __init__(self, contract):
-        self.title = contract.description
+        self.title = better_title(contract.description)
         self.opportunity_type = ContractType.get_type(current_app.config.get('CONDUCTOR_TYPE', ''))
         self.department = Department.get_dept(current_app.config.get('CONDUCTOR_DEPARTMENT', ''))
 

--- a/purchasing/data/contracts.py
+++ b/purchasing/data/contracts.py
@@ -328,6 +328,10 @@ class ContractType(Model):
     def query_factory_all(cls):
         return cls.query.order_by(cls.name)
 
+    @classmethod
+    def get_type(cls, type_name):
+        return cls.query.filter(db.func.lower(cls.name) == type_name.lower()).first()
+
 class ContractProperty(RefreshSearchViewMixin, Model):
     __tablename__ = 'contract_property'
 

--- a/purchasing/settings.py
+++ b/purchasing/settings.py
@@ -34,6 +34,8 @@ class Config(object):
     BROKER_POOL_LIMIT = None
     SERVER_NAME = os_env.get('BROWSERID_URL')
     DISPLAY_TIMEZONE = pytz.timezone(os_env.get('DISPLAY_TIMEZONE', 'US/Eastern'))
+    CONDUCTOR_TYPE = 'County'
+    CONDUCTOR_DEPARTMENT = 'Multiple Departments'
 
 class ProdConfig(Config):
     """Production configuration."""

--- a/purchasing/templates/conductor/detail/_post_opportunities.html
+++ b/purchasing/templates/conductor/detail/_post_opportunities.html
@@ -23,12 +23,6 @@
       </div><!-- department -->
 
       <div class="form-group">
-        <label for="contact_email" class="control-label">Contact Email <span class="form-required">*</span></label>
-        <p class="help-block">What is the email of the primary contact for this opportunity?</p>
-        {{ macros.with_errors(form.contact_email, class_="form-control", placeholder="ex: example@pittsburghpa.gov")}}
-      </div><!-- email -->
-
-      <div class="form-group">
         <label for="opportunity_type" class="control-label">Opportunity Type <span class="form-required">*</span></label>
         <p class="help-block">What type of opportunity is this?</p>
         {{ macros.with_errors(form.opportunity_type, class="form-control") }}
@@ -104,6 +98,7 @@
           <p class="help-block">Feel free to choose as many categories as you would like.</p>
         </div>
 
+        {% set opportunity = contract.opportunity %}
         {% include 'opportunities/_categories.html' %}
 
       </div>

--- a/purchasing/templates/opportunities/_categories.html
+++ b/purchasing/templates/opportunities/_categories.html
@@ -13,6 +13,19 @@
     </div>
   </div>
 
+  {% if opportunity and opportunity.categories|length > 0 %}
+  <div class="form-group">
+    <div class="col-sm-12">
+      <label>Currently Assigned Categories:</label>
+      <ul>
+        {% for category in opportunity.categories %}
+        <li>{{ category.category_friendly_name }}</li>
+        {% endfor %}
+      </ul>
+    </div>
+  </div>
+  {% endif %}
+
   <div class="form-group">
     <div class="col-sm-12">
       {{ macros.with_errors(form.categories, class_="form-control col-sm-12 js-category-select", id="category-0") }}

--- a/purchasing/templates/opportunities/front/detail.html
+++ b/purchasing/templates/opportunities/front/detail.html
@@ -35,7 +35,11 @@
             <p class="help-block">
             <strong>Tags:</strong>
             {% for category in opportunity.categories %}
-              {% if loop.index <= 3 %}{{ category.category_friendly_name }};{% endif %}
+              {% if loop.index <= 3 %}
+                {{ category.category_friendly_name }}
+                {% if opportunity.categories|length > 3 or not loop.last %};
+                {% endif %}
+              {% endif %}
             {% endfor %}
             {% if opportunity.categories|length > 3 %} and {{ opportunity.categories|length - 3 }} more{% endif %}
             </p>
@@ -147,8 +151,12 @@
         {% endfor %}
 
         <h3><strong>Have a question?</strong></h3>
-        <div class="">
+        <div>
+          {% if opportunity.contact.email %}
           <p>We'd be happy to answer it! Send it in to {% if opportunity.contact.first_name and opportunity.contact.last_name %}{{ opportunity.contact.first_name }} {{ opportunity.contact.last_name }} at {% endif %} <a href="mailto:{{ opportunity.contact.email }}">{{ opportunity.contact.email }}</a>.{% if opportunity.has_docs %}</p><p> Please refer to the timeline section of the opportunity documents to see when the question &amp; answer period opens and closes.{% endif %}</p>
+          {% else %}
+            <p>Please visit the <a href="http://www.govbids.com/scripts/PAPG/public/home1.asp" target="_blank">Pennyslvania Purchasing Group</a> site to look up this opportunity. Instructions for sending in a question can be found on the IFB document uploaded there. </p>
+          {% endif %}
         </div>
 
       </div>

--- a/purchasing/templates/opportunities/front/detail.html
+++ b/purchasing/templates/opportunities/front/detail.html
@@ -11,7 +11,7 @@
     <div class="row">
 
       <div class="col-md-10">
-        <h1>{{ opportunity.title }}</h1>
+        <h1>{{ opportunity.title|title }}</h1>
 
         {% if opportunity.can_edit(current_user) %}
         <p><a href="{{ url_for('opportunities_admin.edit', opportunity_id=opportunity.id) }}">Edit this opportunity</a></p>

--- a/purchasing/users/models.py
+++ b/purchasing/users/models.py
@@ -91,6 +91,10 @@ class Department(SurrogatePK, Model):
         return cls.query.filter(cls.name != 'New User')
 
     @classmethod
+    def get_dept(cls, type_name):
+        return cls.query.filter(db.func.lower(cls.name) == type_name.lower()).first()
+
+    @classmethod
     def choices(cls, blank=False):
         departments = [(i.id, i.name) for i in cls.query_factory().all()]
         if blank:

--- a/purchasing_test/integration/conductor/test_conductor_upload.py
+++ b/purchasing_test/integration/conductor/test_conductor_upload.py
@@ -52,8 +52,6 @@ class TestUploadBase(BaseTestCase):
 
 class TestCostarsUpload(TestUploadBase):
     def test_page_locked(self):
-        '''Test page won't render for people without proper roles
-        '''
         # test that you can't access upload page unless you are signed in with proper role
         self.assertEqual(self.client.get('/conductor/upload/costars').status_code, 302)
         self.assert_flashes('This feature is for city staff only. If you are staff, log in with your pittsburghpa.gov email using the link to the upper right.', 'alert-warning')
@@ -63,8 +61,6 @@ class TestCostarsUpload(TestUploadBase):
             self.assert200(self.client.get('/conductor/upload/costars'))
 
     def test_upload_locked(self):
-        '''Test upload doesn't work without proper role
-        '''
         test_file = self.create_file('costars-99.csv', 'text/csv')
         upload_csv = self.client.post('/conductor/upload/costars', data=dict(upload=test_file))
         self.assertEqual(upload_csv.status_code, 302)
@@ -77,8 +73,6 @@ class TestCostarsUpload(TestUploadBase):
             self.assertTrue(req.data.count('Upload processing...'), 1)
 
     def test_upload_validation(self):
-        '''Test that only csv's can be uploaded
-        '''
         self.login_user(self.conductor)
 
         txt_file = self.create_file('test.txt', 'text/plain')
@@ -90,8 +84,6 @@ class TestCostarsUpload(TestUploadBase):
         self.assertEquals(upload_csv.location, 'http://localhost/conductor/upload/costars/processing')
 
     def test_upload_success(self):
-        '''Test that file upload works and updates database
-        '''
         self.login_user(self.conductor)
         costars_filepath = current_app.config.get('PROJECT_ROOT') + '/purchasing_test/mock/COSTARS-1.csv'
         costars_filename = 'COSTARS-1.csv'
@@ -142,21 +134,15 @@ class TestCostarsContractUpload(TestUploadBase):
         super(TestCostarsContractUpload, self).tearDown()
 
     def test_app_locked(self):
-        '''Test that the views are gated
-        '''
         self.assertEquals(self.client.get('/conductor/upload/costars/contracts').status_code, 302)
         self.assertEquals(self.client.post('/conductor/upload/costars/contracts').status_code, 302)
 
     def test_contract_upload_view(self):
-        '''Test the upload contract views work as expected
-        '''
         self.login_user(self.admin)
         self.assert200(self.client.get('/conductor/upload/costars/contracts'))
         self.assertEquals(len(self.get_context_variable('contracts')), 3)
 
     def test_contract_upload(self):
-        '''Test that uploading contracts work as expected
-        '''
         self.login_user(self.admin)
         test_file = self.create_file('test.pdf', 'application/pdf')
         self.client.post(

--- a/purchasing_test/integration/import/test_scrape_county.py
+++ b/purchasing_test/integration/import/test_scrape_county.py
@@ -18,9 +18,6 @@ from purchasing_test.test_base import BaseTestCase
 
 class TestScrapeCounty(BaseTestCase):
     def test_scrape_county(self):
-        '''
-        Test the building of new line item links.
-        '''
         with open(current_app.config.get('PROJECT_ROOT') + '/purchasing_test/mock/all_bids.html', 'r') as f:
             main_page = BeautifulSoup(
                 f.read(), from_encoding='windows-1252'
@@ -36,9 +33,6 @@ class TestScrapeCounty(BaseTestCase):
         self.assertTrue(len(line_item_links) == 13)
 
     def test_import_line_items(self):
-        '''
-        Test that award information is scraped properly.
-        '''
         muni = Company.create(**dict(company_name='U.S. Municipal Supply, Inc.'))
         chemung = Company.create(**dict(company_name='Chemung Supply Corporation'))
         pathmaster = Company.create(**dict(company_name='Path Master, Inc., Co.'))

--- a/purchasing_test/integration/opportunities/test_opportunities_front.py
+++ b/purchasing_test/integration/opportunities/test_opportunities_front.py
@@ -18,8 +18,6 @@ class TestOpportunities(TestOpportunitiesFrontBase):
     render_templates = True
 
     def test_templates(self):
-        '''Test templates used, return 200
-        '''
         # insert our opportunity, users
         admin_role = insert_a_role('admin')
         admin = insert_a_user(role=admin_role)
@@ -46,8 +44,6 @@ class TestOpportunities(TestOpportunitiesFrontBase):
                 self.assert200(response)
 
     def test_index(self):
-        '''Test index page works as expected
-        '''
         response = self.client.get('/beacon/')
         self.assert200(response)
         self.assert_template_used('opportunities/front/splash.html')
@@ -62,8 +58,6 @@ class TestOpportunities(TestOpportunitiesFrontBase):
         self.assertTrue('foo@foo.com' in signup.data)
 
     def test_signup(self):
-        '''Test signups work as expected including validation errors, signups, etc.
-        '''
         admin_role = insert_a_role('admin')
         superadmin_role = insert_a_role('superadmin')
 
@@ -196,8 +190,6 @@ class TestOpportunities(TestOpportunitiesFrontBase):
                 self.assertEquals(session['business_name'], 'foo')
 
     def test_signup_different_business_name(self):
-        '''Signing up with a different business name shouldn't break it
-        '''
         self.client.post('/beacon/signup', data={
             'email': 'foo2@foo.com',
             'business_name': 'foo',
@@ -225,8 +217,6 @@ class TestOpportunities(TestOpportunitiesFrontBase):
         self.assertEquals(Vendor.query.first().business_name, 'bar')
 
     def test_manage_subscriptions(self):
-        '''Test subscription and unsubscription management
-        '''
         self.client.post('/beacon/signup', data={
             'email': 'foo2@foo.com',
             'business_name': 'foo',
@@ -279,8 +269,6 @@ class TestOpportunities(TestOpportunitiesFrontBase):
 
 class TestOpportunitiesSubscriptions(TestOpportunitiesAdminBase):
     def test_signup_for_multiple_opportunities(self):
-        '''Test signup for multiple opportunities
-        '''
         self.assertEquals(Vendor.query.count(), 1)
         # duplicates should get filtered out
         post = self.client.post('/beacon/opportunities', data=MultiDict([
@@ -302,14 +290,10 @@ class TestOpportunitiesSubscriptions(TestOpportunitiesAdminBase):
         self.assert_flashes('Successfully subscribed for updates!', 'alert-success')
 
     def test_unicode_get(self):
-        '''Test that you can view a page w/unicode encoded data
-        '''
         self.login_user(self.admin)
         self.assert200(self.client.get('/beacon/opportunities/{}'.format(self.opportunity1.id)))
 
     def test_signup_for_opportunity(self):
-        '''Test signup for individual opportunities
-        '''
         with mail.record_messages() as outbox:
             self.assertEquals(Vendor.query.count(), 1)
             post = self.client.post('/beacon/opportunities/{}'.format(self.opportunity3.id), data={

--- a/purchasing_test/integration/public/test_public.py
+++ b/purchasing_test/integration/public/test_public.py
@@ -17,8 +17,6 @@ class TestPublic(BaseTestCase):
         self.staff = insert_a_user(email='foo2@foo.com', role=self.staff_role_id)
 
     def test_public(self):
-        '''Make sure that all of the public pages work as expected
-        '''
         public_viewer = self.client.get('/')
         self.assert200(public_viewer)
         self.assertTrue('<i class="fa fa-train fa-stack-1x fa-body-bg"></i>' not in public_viewer.data)

--- a/purchasing_test/integration/sherpa/test_sherpa.py
+++ b/purchasing_test/integration/sherpa/test_sherpa.py
@@ -13,9 +13,6 @@ class TestSherpa(BaseTestCase):
         self.user = insert_a_user(email=self.email, role=self.staff_role)
 
     def test_sherpa(self):
-        '''
-        Checks that Sherpa endpoints return 200 success codes use correct templates.
-        '''
         self.login_user(self.user)
 
         for rule in current_app.url_map.iter_rules():

--- a/purchasing_test/integration/users/test_users.py
+++ b/purchasing_test/integration/users/test_users.py
@@ -20,9 +20,6 @@ class TestUserAuth(BaseTestCase):
         self.department1 = DepartmentFactory.create(name='Test').save()
 
     def test_login_route(self):
-        '''
-        Test the login route works properly
-        '''
         request = self.client.get('/users/login')
         self.assert200(request)
         self.assert_template_used('users/login.html')
@@ -30,17 +27,11 @@ class TestUserAuth(BaseTestCase):
         self.assertTrue(self.get_context_variable('current_user').is_anonymous())
 
     def test_thispage(self):
-        '''
-        Test the thispage utility properly populates
-        '''
         request = self.client.get('/about', follow_redirects=True)
         self.assertTrue('?next=%2Fabout%2F' in request.data)
 
     @patch('urllib2.urlopen')
     def test_auth_persona_failure(self, urlopen):
-        '''
-        Test that we reject when persona throws bad statuses to us
-        '''
         mock_open = Mock()
         mock_open.read.side_effect = ['{"status": "error"}']
         urlopen.return_value = mock_open
@@ -53,9 +44,6 @@ class TestUserAuth(BaseTestCase):
 
     @patch('urllib2.urlopen')
     def test_auth_no_user(self, urlopen):
-        '''
-        Test that we reject bad email addresses
-        '''
         mock_open = Mock()
         mock_open.read.side_effect = ['{"status": "okay", "email": "not_a_valid_email"}']
         urlopen.return_value = mock_open
@@ -68,9 +56,6 @@ class TestUserAuth(BaseTestCase):
 
     @patch('urllib2.urlopen')
     def test_auth_success(self, urlopen):
-        '''
-        Test that we properly login users
-        '''
         mock_open = Mock()
         mock_open.read.side_effect = [
             '{"status": "okay", "email": "' + self.email + '"}',
@@ -89,8 +74,6 @@ class TestUserAuth(BaseTestCase):
 
     @patch('urllib2.urlopen')
     def test_new_user_success(self, urlopen):
-        '''Test that we properly register and onboard new users with a city domain
-        '''
         # insert all of our roles
         insert_a_role('superadmin')
         insert_a_role('admin')
@@ -146,10 +129,6 @@ class TestUserAuth(BaseTestCase):
 
     @patch('urllib2.urlopen')
     def test_logout(self, urlopen):
-        '''
-        Test that we can logout properly
-        '''
-
         login_user(User.query.all()[0])
 
         logout = self.client.get('/users/logout', follow_redirects=True)

--- a/purchasing_test/integration/wexplorer/test_wexplorer.py
+++ b/purchasing_test/integration/wexplorer/test_wexplorer.py
@@ -44,8 +44,6 @@ class Testscout(BaseTestCase):
         )
 
     def test_explore(self):
-        '''Ensure explore endpoint works as expected
-        '''
         request = self.client.get('/scout/')
         # test the request processes correctly
         self.assert200(request)
@@ -53,8 +51,6 @@ class Testscout(BaseTestCase):
         self.assertTrue(self.get_context_variable('search_form') is not None)
 
     def test_companies(self):
-        '''Test that the companies page works as expected, including throwing 404s where appropriate
-        '''
         request = self.client.get('/scout/companies/{}'.format(self.company1.id))
         # test that this works
         self.assert200(request)
@@ -66,8 +62,6 @@ class Testscout(BaseTestCase):
         self.assert404(self.client.get('/scout/companies/999'))
 
     def test_contracts(self):
-        '''Test that the contracts page works as expected, including throwing 404s where appropriate
-        '''
         request = self.client.get('/scout/contracts/{}'.format(self.contract1.id))
         self.assert200(request)
         # test that we have the wrapped form and the company object
@@ -78,8 +72,6 @@ class Testscout(BaseTestCase):
         self.assert404(self.client.get('/scout/contracts/999'))
 
     def test_subscribe(self):
-        '''Test all possible combinations of subscribing to a contract
-        '''
         # test that you can't subscribe to a contract unless you are signed in
         request = self.client.get('/scout/contracts/{}/subscribe'.format(self.contract1.id))
         self.assertEquals(request.status_code, 302)
@@ -101,8 +93,6 @@ class Testscout(BaseTestCase):
         self.assert404(self.client.get('/scout/contracts/999/subscribe'))
 
     def test_unsubscribe(self):
-        '''Test ability to unsubscribe from a contract
-        '''
         # test that you can't subscribe to a contract unless you are signed in
         request = self.client.get('/scout/contracts/{}/unsubscribe'.format(self.contract1.id))
         self.assertEquals(request.status_code, 302)
@@ -129,8 +119,6 @@ class Testscout(BaseTestCase):
         self.assert404(self.client.get('/scout/contracts/999/unsubscribe'))
 
     def test_department_filter(self):
-        '''Test that filter page works properly and shows the error where appropriate
-        '''
         self.login_user(self.admin_user)
         # assert it works with no subscriptions
         self.assert200(self.client.get('/scout/filter/{}'.format(self.admin_user.department_id)))
@@ -157,8 +145,6 @@ class Testscout(BaseTestCase):
         self.assertEquals(request.status_code, 404)
 
     def test_notes(self):
-        '''Test taking notes on scout
-        '''
         # assert you can't take a note on a contract
         self.assertEquals(ContractNote.query.count(), 0)
         self.client.post('/scout/contracts/{}'.format(self.contract1.id), data=dict(note='test', user=current_user.id))
@@ -183,8 +169,6 @@ class Testscout(BaseTestCase):
         self.assertTrue('NOTENOTENOTE' not in no_note_two.data)
 
     def test_feedback(self):
-        '''Test scout contract feedback mechanism
-        '''
         self.assert200(self.client.get('/scout/contracts/{}/feedback'.format(self.contract1.id)))
         self.assert_template_used('scout/feedback.html')
 

--- a/purchasing_test/integration/wexplorer/test_wexplorer_search.py
+++ b/purchasing_test/integration/wexplorer/test_wexplorer_search.py
@@ -72,9 +72,6 @@ class TestscoutSearch(BaseTestCase):
         db.get_engine(self.app).dispose()
 
     def test_search(self):
-        '''Check searches return properly: descriptions, names, properties, line items, financial ids
-        '''
-
         db.session.execute('''
             REFRESH MATERIALIZED VIEW CONCURRENTLY search_view
         ''')


### PR DESCRIPTION
### What Changed

As per phone discussion yesterday and the notes at the bottom of #540, we are slightly modifying the Conductor-to-Beacon post flow.
- Documents are not required to be uploaded
- Opportunity type is defaulted to a configurable value
- Department is defaulted to a configurable value (Multiple Departments in the screenshot, but could easily be something else)
- Title is now by default the name of the opportunity used in conductor
- Contact email is no longer required
### Issues
- Fixes #540 
### Still needed
- We still need default copy that should exist if there isn't a contact email address (cc @rileystewart)
### Screenshot

![screen shot 2015-10-29 at 11 18 55 am](https://cloud.githubusercontent.com/assets/1957344/10827940/dee4611a-7e2e-11e5-83cb-91395dfa5e0d.png)
